### PR TITLE
MSK-278 - ProducerRegistryAPI: after initial cache construction producer...

### DIFF
--- a/moskito-core/java/net/anotheria/moskito/core/registry/ProducerReference.java
+++ b/moskito-core/java/net/anotheria/moskito/core/registry/ProducerReference.java
@@ -9,24 +9,56 @@ import net.anotheria.moskito.core.producers.IStatsProducer;
  *
  */
 public class ProducerReference {
-	/**
+
+    /**
+     * Producer id reference links to.
+     */
+    private final String producerId;
+
+    /**
 	 * Link to the producer. TODO in the future it should/could be a WeakReference.
 	 */
 	private final IStatsProducer target;
-	
-	public ProducerReference(IStatsProducer aProducer){
-		target = aProducer;
+
+    /**
+     * Constructor.
+     *
+     * @param aProducer {@link net.anotheria.moskito.core.producers.IStatsProducer} created reference will be linked to
+     */
+	public ProducerReference(final IStatsProducer aProducer){
+        if (aProducer == null) {
+            throw new IllegalArgumentException("Parameter aProducer is null");
+        }
+
+        this.producerId = aProducer.getProducerId();
+        this.target = aProducer;
 	}
 
 	/**
 	 * Returns the underlying stats producer.
-	 * @return
+	 *
+     * @return referenced {@link net.anotheria.moskito.core.producers.IStatsProducer}
 	 */
 	public IStatsProducer get(){
 		return target;
 	}
-	
-	@Override public String toString(){
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ProducerReference that = (ProducerReference) o;
+
+        return !(producerId != null ? !producerId.equals(that.producerId) : that.producerId != null);
+    }
+
+    @Override
+    public int hashCode() {
+        return producerId != null ? producerId.hashCode() : 0;
+    }
+
+    @Override public String toString(){
 		return "PR->"+get();
 	}
 }

--- a/moskito-core/java/net/anotheria/moskito/core/registry/ProducerRegistryAPIImpl.java
+++ b/moskito-core/java/net/anotheria/moskito/core/registry/ProducerRegistryAPIImpl.java
@@ -128,19 +128,22 @@ public class ProducerRegistryAPIImpl implements IProducerRegistryAPI, IProducerR
 	private void rebuildProducerCache(Collection<IStatsProducer> producers){
 		log.debug("Rebuilding producer cache with "+producers.size()+" producers.");
 		log.debug("Following producers known: "+producers);
-		synchronized(cacheLock){
+
+        synchronized(cacheLock){
 			//lets create lists with more place to store as actually need, we will probably need it.
-			int approxSize = (int)(producers.size()*1.5);
-			_cachedProducerList = new ArrayList<ProducerReference>(approxSize);
-			for (IStatsProducer sp : producers){
-				_cachedProducerList.add(new ProducerReference(sp));	
-			}
-			
-			
-			_cachedProducerMap = new HashMap<String,ProducerReference>(approxSize);
-			for (IStatsProducer p : producers)
-				_cachedProducerMap.put(p.getProducerId(), new ProducerReference(p));
+			final int approxSize = (int)(producers.size()*1.5);
+
+            _cachedProducerList = new ArrayList<ProducerReference>(approxSize);
+            _cachedProducerMap = new HashMap<String,ProducerReference>(approxSize);
+
+            for (IStatsProducer sp : producers){
+				final ProducerReference reference = new ProducerReference(sp);
+
+                _cachedProducerList.add(reference);
+                _cachedProducerMap.put(sp.getProducerId(), reference);
+            }
 		}
+
 		if (log.isDebugEnabled()){
 			log.debug("Cachedproducer list contains "+_cachedProducerList.size()+" producers: ");
 			log.debug(""+_cachedProducerList);

--- a/moskito-core/test/junit/net/anotheria/moskito/core/registry/ProducerReferenceTest.java
+++ b/moskito-core/test/junit/net/anotheria/moskito/core/registry/ProducerReferenceTest.java
@@ -1,0 +1,61 @@
+package net.anotheria.moskito.core.registry;
+
+import junit.framework.Assert;
+import net.anotheria.moskito.core.producers.IStatsProducer;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * {@link net.anotheria.moskito.core.registry.ProducerReference} test.
+ *
+ * @author Alex Osadchy
+ */
+public class ProducerReferenceTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentException() {
+        new ProducerReference(null);
+    }
+
+    @Test
+    public void shouldBeEquals() {
+        IStatsProducer producer = createTestProducer("test_producer_id");
+
+        ProducerReference ref_1 = new ProducerReference(producer);
+        ProducerReference ref_2 = new ProducerReference(producer);
+
+        Assert.assertNotSame("References should have different identities", ref_1, ref_2);
+        Assert.assertEquals("References should be equal", ref_1, ref_2);
+    }
+
+    /**
+     * Creates {@link net.anotheria.moskito.core.producers.IStatsProducer} for testing.
+     *
+     * @param producerId producer id
+     * @return {@link net.anotheria.moskito.core.producers.IStatsProducer}
+     */
+    private IStatsProducer createTestProducer(final String producerId) {
+        return new IStatsProducer() {
+            @Override
+            public List getStats() {
+                return null;
+            }
+
+            @Override
+            public String getProducerId() {
+                return producerId;
+            }
+
+            @Override
+            public String getCategory() {
+                return null;
+            }
+
+            @Override
+            public String getSubsystem() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
...s don't properly unregistered
- equals/hashCode methods are overridden in ProducerReference
- added JUnit test
- during initial cache init one instance of ProducerReference is used in both caches inside ProducerRegistryAPIImpl
