### PR TITLE
replace println with logger

### DIFF
--- a/moskito-core/src/main/java/net/anotheria/moskito/core/plugins/NoOpPlugin.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/plugins/NoOpPlugin.java
@@ -1,5 +1,9 @@
 package net.anotheria.moskito.core.plugins;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 /**
  * A noop plugin is used for generic testing of plugin interface.
  *
@@ -7,13 +11,15 @@ package net.anotheria.moskito.core.plugins;
  * @since 19.03.13 15:55
  */
 public class NoOpPlugin extends AbstractMoskitoPlugin{
+	private static final Logger LOGGER = LoggerFactory.getLogger(NoOpPlugin.class);
+
 	@Override
 	public void initialize() {
-		System.out.println(this.getClass().getSimpleName()+" initialized");
+		LOGGER.info(this.getClass().getSimpleName()+" initialized");
 	}
 
 	@Override
 	public void deInitialize() {
-		System.out.println(this.getClass().getSimpleName()+" de-initialized");
+		LOGGER.info(this.getClass().getSimpleName()+" de-initialized");
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/usecase/recorder/UseCaseRecorderCommandProcessor.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/usecase/recorder/UseCaseRecorderCommandProcessor.java
@@ -4,6 +4,8 @@ import net.anotheria.moskito.core.calltrace.CurrentlyTracedCall;
 import net.anotheria.moskito.core.calltrace.RunningTraceContainer;
 import net.anotheria.moskito.core.calltrace.TracedCall;
 import net.anotheria.moskito.core.command.CommandProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -14,6 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  */
 public class UseCaseRecorderCommandProcessor implements CommandProcessor{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(UseCaseRecorderCommandProcessor.class);
 
 	/**
 	 * Parameter name that triggers the recorder.
@@ -33,14 +37,14 @@ public class UseCaseRecorderCommandProcessor implements CommandProcessor{
 			useCaseName = "unnamed"+unnamedCounter.incrementAndGet();
 		RunningTraceContainer.startTracedCall(useCaseName);
 		
-		System.out.println("Starting command: "+useCaseName);
+		LOGGER.info("Starting command: "+useCaseName);
 	}
 
 	@Override
 	public void stopCommand(String command, Map<String, String[]> parameters) {
-		System.out.println("Stoping command: "+command);
+		LOGGER.info("Stoping command: "+command);
 		TracedCall last = RunningTraceContainer.endTrace();
-		System.out.println("LAST_ "+last);
+		LOGGER.info("LAST_ "+last);
 		UseCaseRecorderFactory.getUseCaseRecorder().addRecordedUseCase((CurrentlyTracedCall)last);
 	}
 	

--- a/moskito-inspect-standalone/src/main/java/net/anotheria/moskitominimal/listeners/SetupThresholds.java
+++ b/moskito-inspect-standalone/src/main/java/net/anotheria/moskitominimal/listeners/SetupThresholds.java
@@ -5,19 +5,22 @@ import net.anotheria.moskito.core.threshold.ThresholdStatus;
 import net.anotheria.moskito.core.threshold.Thresholds;
 import net.anotheria.moskito.core.threshold.guard.GuardedDirection;
 import net.anotheria.moskito.core.threshold.guard.LongBarrierPassGuard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
 public class SetupThresholds implements ServletContextListener{
+	private static final Logger LOGGER = LoggerFactory.getLogger(SetupThresholds.class);
 
 	@Override
 	public void contextInitialized(ServletContextEvent sce) {
 		
-		System.out.println("Configuring thresholds ... ");
+		LOGGER.info("Configuring thresholds ... ");
 		setupMemory();
 		setupThreadCount();
-		System.out.println(" ... done.");
+		LOGGER.info(" ... done.");
 	}
 	
 	private void setupMemory() {

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/BaseShowProducersAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/BaseShowProducersAction.java
@@ -161,7 +161,7 @@ public abstract class BaseShowProducersAction extends BaseMoskitoUIAction {
 						GraphDataBean bean = graphData.get(graphKey); 
 						if (bean==null) {
 						    // FIXME!
-						    System.out.println("unable to find bean for key: " + graphKey);
+						    LOG.warn("unable to find bean for key: " + graphKey);
 						} else {
 						    bean.addValue(new GraphDataValueBean(p.getProducerId(), valueBean.getRawValue()));
 						}

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threads/api/ThreadAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threads/api/ThreadAPIImpl.java
@@ -4,6 +4,8 @@ import net.anotheria.anoplass.api.APIException;
 import net.anotheria.moskito.core.util.threadhistory.ThreadHistoryUtility;
 import net.anotheria.moskito.webui.shared.api.AbstractMoskitoAPIImpl;
 import net.anotheria.util.NumberUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -19,6 +21,9 @@ import java.util.List;
  * @since 14.02.13 11:45
  */
 public class ThreadAPIImpl extends AbstractMoskitoAPIImpl implements ThreadAPI {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ThreadAPIImpl.class);
+
 	@Override
 	public List<ThreadInfoAO> getThreadInfos() throws APIException {
 		ThreadMXBean mxBean = ManagementFactory.getThreadMXBean();
@@ -59,7 +64,7 @@ public class ThreadAPIImpl extends AbstractMoskitoAPIImpl implements ThreadAPI {
 		});
 		t.setName("TestThread_at_"+ NumberUtils.makeISO8601TimestampString());
 		t.start();
-		System.out.println("Started TEST thread: "+t.getId()+", "+t.getName());
+		LOGGER.info("Started TEST thread: "+t.getId()+", "+t.getName());
 
 	}
 


### PR DESCRIPTION
To reduce the output in catalina.out, this commit replaces the logger instead of println to stdout.