### PR TITLE
Please add this to provide Java 8 compiler support

### DIFF
--- a/moskito-aop/pom.xml
+++ b/moskito-aop/pom.xml
@@ -12,44 +12,12 @@
   	<version>2.7.5-SNAPSHOT</version>
     <name>moskito aop</name>
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>aspectj-maven-plugin</artifactId>
-                <version>${aspectj-maven-plugin.version}</version>
-				<configuration>
-					<complianceLevel>${aspectj-maven-plugin.complianceLevel}</complianceLevel>
-					<source>${source-version}</source>
-					<target>${target-version}</target>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.aspectj</groupId>
-						<artifactId>aspectjrt</artifactId>
-						<version>${aspectj.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.aspectj</groupId>
-						<artifactId>aspectjtools</artifactId>
-						<version>${aspectj.version}</version>
-					</dependency>
-				</dependencies>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <!-- use this goal to weave all your main classes -->
-                            <goal>test-compile</goal>
-                            <!-- use this goal to weave all your test classes -->
-                        </goals>
-                        <configuration>
-							<source>${source-version}</source>
-							<target>${target-version}</target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>aspectj-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
         <pluginManagement>
         	<plugins>
         		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
@@ -96,11 +64,6 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-			<version>${aspectj.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjtools</artifactId>
 			<version>${aspectj.version}</version>
         </dependency>
 	  <dependency>

--- a/moskito-aop/pom.xml
+++ b/moskito-aop/pom.xml
@@ -64,7 +64,6 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-			<version>${aspectj.version}</version>
         </dependency>
 	  <dependency>
 	      <groupId>ch.qos.logback</groupId>

--- a/moskito-aop/pom.xml
+++ b/moskito-aop/pom.xml
@@ -11,28 +11,29 @@
     <artifactId>moskito-aop</artifactId>
   	<version>2.7.5-SNAPSHOT</version>
     <name>moskito aop</name>
-	<properties>
-		<aspectj.version>1.7.4</aspectj.version>
-	</properties>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${aspectj-maven-plugin.version}</version>
+				<configuration>
+					<complianceLevel>${aspectj-maven-plugin.complianceLevel}</complianceLevel>
+					<source>${source-version}</source>
+					<target>${target-version}</target>
+				</configuration>
 				<dependencies>
-		        <dependency>
-		            <groupId>org.aspectj</groupId>
-		            <artifactId>aspectjrt</artifactId>
-					<version>${aspectj.version}</version>
-		        </dependency>
-		        <dependency>
-		            <groupId>org.aspectj</groupId>
-		            <artifactId>aspectjtools</artifactId>
-					<version>${aspectj.version}</version>
-		        </dependency>
-		</dependencies>
-
+					<dependency>
+						<groupId>org.aspectj</groupId>
+						<artifactId>aspectjrt</artifactId>
+						<version>${aspectj.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.aspectj</groupId>
+						<artifactId>aspectjtools</artifactId>
+						<version>${aspectj.version}</version>
+					</dependency>
+				</dependencies>
                 <executions>
                     <execution>
                         <goals>
@@ -42,8 +43,8 @@
                             <!-- use this goal to weave all your test classes -->
                         </goals>
                         <configuration>
-                            <source>1.7</source>
-                            <target>1.7</target>
+							<source>${source-version}</source>
+							<target>${target-version}</target>
                         </configuration>
                     </execution>
                 </executions>
@@ -68,7 +69,7 @@
         									aspectj-maven-plugin
         								</artifactId>
         								<versionRange>
-        									[1.4,)
+        									[${aspectj-maven-plugin.version},)
         								</versionRange>
         								<goals>
         									<goal>compile</goal>

--- a/moskito-aop/pom.xml
+++ b/moskito-aop/pom.xml
@@ -108,5 +108,10 @@
 	      <artifactId>logback-classic</artifactId>
 		  <scope>test</scope>
 	  </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/moskito-aop/pom.xml
+++ b/moskito-aop/pom.xml
@@ -72,7 +72,7 @@
 	  </dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
+			<artifactId>hamcrest-all</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
@@ -89,7 +89,7 @@ public class AbstractMoskitoAspect<S extends IStats> {
     private void createMethodLevelAccumulators(OnDemandStatsProducer<S> producer, Method method) {
         //several @Accumulators in accumulators holder
         Accumulates accAnnotationHolderMethods = (Accumulates) method.getAnnotation(Accumulates.class);
-        if (accAnnotationHolderMethods != null && accAnnotationHolderMethods.value() != null) {
+        if (accAnnotationHolderMethods != null) {
             Accumulate[] accAnnotations  = accAnnotationHolderMethods.value();
             for (Accumulate accAnnotation : accAnnotations) {
                 createAccumulator(
@@ -119,7 +119,7 @@ public class AbstractMoskitoAspect<S extends IStats> {
     private void createClassLevelAccumulators(OnDemandStatsProducer<S> producer, Class producerClass) {
         //several @Accumulators in accumulators holder
         Accumulates accAnnotationHolder = AnnotationUtils.findAnnotation(producerClass, Accumulates.class);//(Accumulates) producerClass.getAnnotation(Accumulates.class);
-        if (accAnnotationHolder != null && accAnnotationHolder.value() != null) {
+        if (accAnnotationHolder != null) {
             Accumulate[] accAnnotations  = accAnnotationHolder.value();
             for (Accumulate accAnnotation : accAnnotations) {
                 createAccumulator(
@@ -165,7 +165,7 @@ public class AbstractMoskitoAspect<S extends IStats> {
                 accName!=null && !accName.isEmpty() && statsName != null && !statsName.isEmpty()){
 
             AccumulatorDefinition definition = new AccumulatorDefinition();
-            if (annotation.name() != null && annotation.name().length() >0) {
+            if (annotation.name().length() > 0) {
                 definition.setName(annotation.name());
             }else{
                 definition.setName(accName);

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
@@ -59,7 +59,7 @@ public class AbstractMoskitoAspect<S extends IStats> {
         OnDemandStatsProducer<S> producer = producers.get(producerId);
         if (producer==null){
 
-            producer = new OnDemandStatsProducer(producerId, getCategory(aCategory), getSubsystem(aSubsystem), factory);
+            producer = new OnDemandStatsProducer<>(producerId, getCategory(aCategory), getSubsystem(aSubsystem), factory);
             producer.setTracingSupported(tracingSupported);
             OnDemandStatsProducer<S> p = producers.putIfAbsent(producerId, producer);
             if (p==null){

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
@@ -15,6 +15,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * The basic aspect class.
@@ -27,7 +28,7 @@ public class AbstractMoskitoAspect<S extends IStats> {
     /**
      * Map with created producers.
      */
-    private Map<String, OnDemandStatsProducer<S>> producers = new ConcurrentHashMap<>();
+    private ConcurrentMap<String, OnDemandStatsProducer<S>> producers = new ConcurrentHashMap<>();
 
     /**
      * Returns the producer for the given pjp and producerId. Registers the producer in the registry if it's not already registered.

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
@@ -13,8 +13,8 @@ import net.anotheria.moskito.core.util.annotation.AnnotationUtils;
 import org.aspectj.lang.ProceedingJoinPoint;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * The basic aspect class.
@@ -27,7 +27,7 @@ public class AbstractMoskitoAspect<S extends IStats> {
     /**
      * Map with created producers.
      */
-    private ConcurrentMap<String, OnDemandStatsProducer<S>> producers = new ConcurrentHashMap<String, OnDemandStatsProducer<S>>();
+    private Map<String, OnDemandStatsProducer<S>> producers = new ConcurrentHashMap<>();
 
     /**
      * Returns the producer for the given pjp and producerId. Registers the producer in the registry if it's not already registered.

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/AbstractMoskitoAspect.java
@@ -53,7 +53,7 @@ public class AbstractMoskitoAspect<S extends IStats> {
         }
 
         if (withMethod)
-            producerId += "."+pjp.getSignature().getName();
+            producerId += '.' +pjp.getSignature().getName();
 
         OnDemandStatsProducer<S> producer = producers.get(producerId);
         if (producer==null){
@@ -142,13 +142,13 @@ public class AbstractMoskitoAspect<S extends IStats> {
 
     private String formAccumulatorNameForMethod(final OnDemandStatsProducer<S> producer, final Accumulate annotation, final Method m) {
         if (producer != null && annotation != null && m != null)
-            return producer.getProducerId()+"."+m.getName()+"."+annotation.valueName()+"."+annotation.intervalName();
+            return producer.getProducerId()+ '.' +m.getName()+ '.' +annotation.valueName()+ '.' +annotation.intervalName();
         return "";
     }
 
     private String formAccumulatorNameForClass(final OnDemandStatsProducer<S> producer, final Accumulate annotation) {
         if (producer != null && annotation != null)
-            return producer.getProducerId()+"."+annotation.valueName()+"."+annotation.intervalName();
+            return producer.getProducerId()+ '.' +annotation.valueName()+ '.' +annotation.intervalName();
         return "";
     }
 

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/CounterAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/CounterAspect.java
@@ -17,7 +17,7 @@ import java.lang.reflect.InvocationTargetException;
  * @author lrosenberg, vzhovtiuk
  */
 @Aspect
-public class CounterAspect extends AbstractMoskitoAspect {
+public class CounterAspect extends AbstractMoskitoAspect<CounterStats> {
 
 	private static final CounterStatsFactory FACTORY = new CounterStatsFactory();
 

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/MonitoringAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/MonitoringAspect.java
@@ -116,7 +116,8 @@ public class MonitoringAspect extends AbstractMoskitoAspect{
                 currentStep.setAborted();
             }
             if (tracePassingOfThisProducer) {
-                call.append(" ERR "+t.getMessage());
+                call.append(" ERR ");
+                call.append(t.getMessage());
             }
             throw t;
         } finally {

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/MonitoringAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/MonitoringAspect.java
@@ -134,7 +134,7 @@ public class MonitoringAspect extends AbstractMoskitoAspect{
                 try {
                     currentStep.appendToCall(" = " + TracingUtil.parameter2string(ret));
                 } catch (Throwable t) {
-                    currentStep.appendToCall(" = ERR: " + t.getMessage() + " (" + t.getClass() + ")");
+                    currentStep.appendToCall(" = ERR: " + t.getMessage() + " (" + t.getClass() + ')');
                 }
             }
             if (currentTrace != null) {

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/MonitoringAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/MonitoringAspect.java
@@ -116,8 +116,7 @@ public class MonitoringAspect extends AbstractMoskitoAspect{
                 currentStep.setAborted();
             }
             if (tracePassingOfThisProducer) {
-                call.append(" ERR ");
-                call.append(t.getMessage());
+                call.append(" ERR ").append(t.getMessage());
             }
             throw t;
         } finally {

--- a/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/MonitoringAspect.java
+++ b/moskito-aop/src/main/java/net/anotheria/moskito/aop/aspect/MonitoringAspect.java
@@ -28,7 +28,7 @@ import java.lang.reflect.InvocationTargetException;
  * @author bvanchuhov
  */
 @Aspect
-public class MonitoringAspect extends AbstractMoskitoAspect{
+public class MonitoringAspect extends AbstractMoskitoAspect<ServiceStats>{
 
 	/**
 	 * Factory constant is needed to prevent continuous reinstantiation of ServiceStatsFactory objects.

--- a/moskito-core/pom.xml
+++ b/moskito-core/pom.xml
@@ -49,5 +49,10 @@
           <artifactId>logback-classic</artifactId>
           <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-all</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/accumulation/AccumulatedValue.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/accumulation/AccumulatedValue.java
@@ -36,7 +36,7 @@ public class AccumulatedValue {
 	}
 	
 	@Override public String toString(){
-		return getISO8601Timestamp()+" "+getValue();
+		return getISO8601Timestamp()+ ' ' +getValue();
 	}
 	
 	public long getTimestamp(){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/accumulation/Accumulator.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/accumulation/Accumulator.java
@@ -100,6 +100,6 @@ public class Accumulator extends AbstractTieable<AccumulatorDefinition> implemen
 	}
 
 	@Override public String toString(){
-		return getId()+" "+getName()+" "+" Def: "+getDefinition()+" active: "+isActivated()+", Values: "+(values==null?"none":""+values.size());
+		return getId()+" "+getName()+" "+" Def: "+getDefinition()+" active: "+isActivated()+", Values: "+(values==null?"none": String.valueOf(values.size()));
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/accumulation/Accumulator.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/accumulation/Accumulator.java
@@ -100,6 +100,6 @@ public class Accumulator extends AbstractTieable<AccumulatorDefinition> implemen
 	}
 
 	@Override public String toString(){
-		return getId()+" "+getName()+" "+" Def: "+getDefinition()+" active: "+isActivated()+", Values: "+(values==null?"none": String.valueOf(values.size()));
+		return getId()+ ' ' +getName()+ ' ' +" Def: "+getDefinition()+" active: "+isActivated()+", Values: "+(values==null?"none": String.valueOf(values.size()));
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/accumulation/AccumulatorRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/accumulation/AccumulatorRepository.java
@@ -20,7 +20,7 @@ import java.util.List;
  * @author lrosenberg
  *
  */
-public final class AccumulatorRepository extends TieableRepository<Accumulator> {
+public final class AccumulatorRepository<S extends IStats> extends TieableRepository<Accumulator, S> {
 
 	/**
 	 * Logger
@@ -30,12 +30,12 @@ public final class AccumulatorRepository extends TieableRepository<Accumulator> 
 	/**
 	 * The singleton instance.
 	 */
-	private static AccumulatorRepository INSTANCE = new AccumulatorRepository();
+	private static AccumulatorRepository<? extends IStats> INSTANCE = new AccumulatorRepository<>();
 	/**
 	 * Returns the singleton instance of the AccumulatorRepository.
 	 * @return the one and only instance.
 	 */
-	public static AccumulatorRepository getInstance(){
+	public static AccumulatorRepository<? extends IStats> getInstance(){
 		return INSTANCE;
 	}
 
@@ -113,7 +113,7 @@ public final class AccumulatorRepository extends TieableRepository<Accumulator> 
 	@SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "This method is for unit testing only.")
     void reset() {
         cleanup();
-		INSTANCE = new AccumulatorRepository();
+		INSTANCE = new AccumulatorRepository<>();
 	}
 
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/blueprint/BlueprintProducersFactory.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/blueprint/BlueprintProducersFactory.java
@@ -20,7 +20,7 @@ public class BlueprintProducersFactory {
 	/**
 	 * Already instantiated producers.
 	 */
-	private static final Map<String, BlueprintProducer> producers = new HashMap<String, BlueprintProducer>();
+	private static final Map<String, BlueprintProducer> producers = new HashMap<>();
 	
 	
 	/**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/blueprint/BlueprintProducersFactory.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/blueprint/BlueprintProducersFactory.java
@@ -46,7 +46,7 @@ public class BlueprintProducersFactory {
 			//end producer lookup
 			return producer;
 		}catch(Exception e){
-			log.error("getBlueprintProducer("+producerId+", "+category+", "+subsystem+")", e);
+			log.error("getBlueprintProducer("+producerId+", "+category+", "+subsystem+ ')', e);
 			throw new RuntimeException("Handler instantiation failed - "+e.getMessage());
 		}
 		

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/calltrace/TraceStep.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/calltrace/TraceStep.java
@@ -91,7 +91,7 @@ public class TraceStep implements Serializable{
 	 */
 	public TraceStep(String aCall, IStatsProducer aProducer){
 		call = aCall;
-		children = new ArrayList<TraceStep>();
+		children = new ArrayList<>();
 		producer = aProducer;
 	}
 	

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/calltrace/TraceStep.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/calltrace/TraceStep.java
@@ -135,7 +135,7 @@ public class TraceStep implements Serializable{
 		if (isAborted())
 			ret.append(" aborted.");
 		else
-			ret.append(".");
+			ret.append('.');
 		return ret.toString();
 	}
 	

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/calltrace/TraceStep.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/calltrace/TraceStep.java
@@ -121,12 +121,16 @@ public class TraceStep implements Serializable{
 
 	/**
 	 * Returns the last step in this execution.
+	 *
 	 * @return this step if it has no chidlren or the last step from the children.
 	 */
-	public TraceStep getLastStep(){
-		if (children==null || children.size()==0)
-			return this;
-		return children.get(children.size()-1).getLastStep();
+	public TraceStep getLastStep() {
+		TraceStep result = this;
+		while (true) {
+			if (result.children == null || result.children.size() == 0)
+				return result;
+			result = result.children.get(result.children.size() - 1);
+		}
 	}
 
 	@Override

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/calltrace/TracingUtil.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/calltrace/TracingUtil.java
@@ -43,7 +43,7 @@ public final class TracingUtil {
 		if (optionalPrefix != null)
 			call.append(optionalPrefix).append(' ');
 
-		call.append(producerId).append('.').append(methodName).append("(");
+		call.append(producerId).append('.').append(methodName).append('(');
 
 		if (parameters != null && parameters.length > 0) {
 			for (int i = 0; i < parameters.length; i++) {
@@ -55,7 +55,7 @@ public final class TracingUtil {
 			}
 		}
 
-		call.append(")");
+		call.append(')');
 
 		return call;
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/command/CommandControllerImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/command/CommandControllerImpl.java
@@ -61,8 +61,8 @@ public enum CommandControllerImpl implements CommandController{
 	/**
 	 * Creates a new CommandControllerImpl.
 	 */
-	private CommandControllerImpl() {
-		processors = new HashMap<String, CommandProcessor>();
+	CommandControllerImpl() {
+		processors = new HashMap<>();
 	}
 	 
 	@Override public void registerCommandProcessor(String command, CommandProcessor processor) {

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/command/CommandControllerImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/command/CommandControllerImpl.java
@@ -86,26 +86,26 @@ public enum CommandControllerImpl implements CommandController{
 	}
 
 	@Override public void startCommand(String command, Map<String, String[]> parameters) {
-		log.debug("startCommand("+command+", "+parameters+")");
+		log.debug("startCommand("+command+", "+parameters+ ')');
 		CommandProcessor processor = processors.get(command);
 		if (processor==null)
 			return;
 		try{
 			processor.startCommand(command, parameters);
 		}catch(Exception e){
-			log.error("caught in startCommand("+command+", "+parameters+")", e);
+			log.error("caught in startCommand("+command+", "+parameters+ ')', e);
 		}
 	}
 
 	@Override public void stopCommand(String command, Map<String, String[]> parameters) {
-		log.debug("stopCommand("+command+", "+parameters+")");
+		log.debug("stopCommand("+command+", "+parameters+ ')');
 		CommandProcessor processor = processors.get(command);
 		if (processor==null)
 			return;
 		try{
 			processor.stopCommand(command, parameters);
 		}catch(Exception e){
-			log.error("caught in stopCommand("+command+", "+parameters+")", e);
+			log.error("caught in stopCommand("+command+", "+parameters+ ')', e);
 		}
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/command/CommandControllerImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/command/CommandControllerImpl.java
@@ -72,8 +72,9 @@ public enum CommandControllerImpl implements CommandController{
 			LoggerFactory.getLogger(CommandControllerImpl.class).debug("registering processor: "+processor+" for command: "+command);
 		}
 		CommandProcessor oldProcessor = processors.put(command, processor);
-		if (oldProcessor!=null)
+		if (oldProcessor!=null) {
 			log.info("Implicitely unregistered processor: "+processor+" for command: "+command);
+		}
 		
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/accumulators/AccumulatorConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/accumulators/AccumulatorConfig.java
@@ -110,6 +110,6 @@ public class AccumulatorConfig implements Serializable {
 	}
 
 	@Override public String toString(){
-		return getName()+" = "+getProducerName()+"."+getStatName()+"."+getValueName()+" "+getIntervalName()+" "+getTimeUnit();
+		return getName()+" = "+getProducerName()+ '.' +getStatName()+ '.' +getValueName()+ ' ' +getIntervalName()+ ' ' +getTimeUnit();
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/dashboards/ChartConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/dashboards/ChartConfig.java
@@ -49,4 +49,18 @@ public class ChartConfig implements Serializable{
 				", caption='" + caption + '\'' +
 				'}';
 	}
+
+	public String buildCaption() {
+		StringBuilder captionBuilder = new StringBuilder();
+
+		int numAccumulators = accumulators.length;
+		for (int i = 0; i < numAccumulators; i++) {
+			String accumulator = accumulators[i];
+			captionBuilder.append(accumulator);
+			if (i != numAccumulators - 1) {
+				captionBuilder.append(' ');
+			}
+		}
+		return captionBuilder.toString();
+	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/gauges/GaugeZoneConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/gauges/GaugeZoneConfig.java
@@ -54,6 +54,6 @@ public class GaugeZoneConfig implements Serializable{
 	}
 
 	@Override public String toString(){
-		return getColor()+": ["+left+", "+right+"]";
+		return getColor()+": ["+left+", "+right+ ']';
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/journey/JourneyConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/journey/JourneyConfig.java
@@ -56,6 +56,6 @@ public class JourneyConfig implements Serializable{
 	}
 
 	public String toString(){
-		return "JourneyConfig: ("+parameterLengthLimit+", "+toStringCollections+", "+toStringMaps+")";
+		return "JourneyConfig: ("+parameterLengthLimit+", "+toStringCollections+", "+toStringMaps+ ')';
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/plugins/PluginConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/plugins/PluginConfig.java
@@ -54,6 +54,6 @@ public class PluginConfig implements Serializable {
 	}
 
 	@Override public String toString(){
-		return "PluginConfig ("+getName()+", "+getClassName()+", "+getConfigurationName()+")";
+		return "PluginConfig ("+getName()+", "+getClassName()+", "+getConfigurationName()+ ')';
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/producers/MBeanProducerConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/producers/MBeanProducerConfig.java
@@ -105,7 +105,7 @@ public class MBeanProducerConfig implements Serializable {
     public String toString() {
         return "MBeanProducerConfig{" + "registerAutomatically=" + registerAutomatically + ", updateAutomatically="
                 + updateAutomatically + ", delayBeforeFirstUpdate=" + delayBeforeFirstUpdate + ", domains="
-                + Arrays.toString(domains) + "}";
+                + Arrays.toString(domains) + '}';
     }
 
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/thresholds/AlertHistoryConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/thresholds/AlertHistoryConfig.java
@@ -37,6 +37,6 @@ public class AlertHistoryConfig implements Serializable {
 	}
 
 	@Override public String toString(){
-		return "{maxNumberOfItems: "+maxNumberOfItems+", toleratedNumberOfItems: "+toleratedNumberOfItems+"}";
+		return "{maxNumberOfItems: "+maxNumberOfItems+", toleratedNumberOfItems: "+toleratedNumberOfItems+ '}';
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/thresholds/GuardConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/thresholds/GuardConfig.java
@@ -73,6 +73,6 @@ public class GuardConfig implements Serializable {
 	}
 
 	@Override public String toString(){
-		return status +" if "+direction+" "+value;
+		return status +" if "+direction+ ' ' +value;
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/config/thresholds/NotificationProviderConfig.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/config/thresholds/NotificationProviderConfig.java
@@ -26,7 +26,7 @@ public class NotificationProviderConfig implements Serializable {
 	@Configure
 	private String guardedStatus = ThresholdStatus.GREEN.name();
 
-	private Map<String,String> properties = new HashMap<String, String>();
+	private Map<String,String> properties = new HashMap<>();
 
 	public String getClassName() {
 		return className;

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/counter/GenericCounterStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/counter/GenericCounterStats.java
@@ -78,7 +78,7 @@ public abstract class GenericCounterStats extends AbstractStats{
 	}
 
 	@Override public String toString(){
-		return getName()+" "+values.values();
+		return getName()+ ' ' +values.values();
 	}
 
 	public Set<String> getPossibleNames(){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/counter/GenericCounterStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/counter/GenericCounterStats.java
@@ -89,7 +89,7 @@ public abstract class GenericCounterStats extends AbstractStats{
 
 	@Override
 	public String getValueByNameAsString(String valueName, String intervalName, TimeUnit timeUnit) {
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 		return String.valueOf(values.get(valueName).getValueAsLong(intervalName));

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/counter/GenericCounterStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/counter/GenericCounterStats.java
@@ -35,7 +35,7 @@ public abstract class GenericCounterStats extends AbstractStats{
 
 	protected GenericCounterStats(String name, Interval[] intervals, String firstCounter, String ... moreCounters){
 		super(name);
-		values = new HashMap<String, StatValue>();
+		values = new HashMap<>();
 		StatValue firstCounterValue = StatValueFactory.createStatValue(Long.valueOf(0L), firstCounter, intervals);
 		addStatValues(firstCounterValue);
 		values.put(firstCounter, firstCounterValue);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/counter/GenericCounterStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/counter/GenericCounterStats.java
@@ -92,7 +92,7 @@ public abstract class GenericCounterStats extends AbstractStats{
 		if (valueName==null || valueName.equals(""))
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
-		return ""+values.get(valueName).getValueAsLong(intervalName);
+		return String.valueOf(values.get(valueName).getValueAsLong(intervalName));
 	}
 
 	@Override

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/DecoratorRegistryImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/DecoratorRegistryImpl.java
@@ -114,7 +114,7 @@ public class DecoratorRegistryImpl implements IDecoratorRegistry {
 	}
 
 	DecoratorRegistryImpl(){
-		registry = new ConcurrentHashMap<String, IDecorator>();
+		registry = new ConcurrentHashMap<>();
 		configure();
 	}
 	

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/DecoratorRegistryImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/DecoratorRegistryImpl.java
@@ -109,8 +109,7 @@ public class DecoratorRegistryImpl implements IDecoratorRegistry {
 	}
 
 	@Override public List<IDecorator> getDecorators(){
-		List<IDecorator> ret = new ArrayList<IDecorator>();
-		ret.addAll(registry.values());
+		List<IDecorator> ret = new ArrayList<IDecorator>(registry.values());
 		return ret;
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/predefined/GenericStatsDecorator.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/predefined/GenericStatsDecorator.java
@@ -33,7 +33,7 @@ public class GenericStatsDecorator implements IDecorator<GenericStats> {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericStatsDecorator.class);
 
     private final String name;
-    private final List<StatCaptionBean> captions = new ArrayList<StatCaptionBean>();
+    private final List<StatCaptionBean> captions = new ArrayList<>();
 
 
     /**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/predefined/PageInBrowserStatsDecorator.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/predefined/PageInBrowserStatsDecorator.java
@@ -65,7 +65,7 @@ public class PageInBrowserStatsDecorator extends AbstractDecorator {
 		long totalWinLoadTime = pageInBrowserStats.getTotalWindowLoadTime(interval, unit);
 		long numberOfLoads = pageInBrowserStats.getNumberOfLoads();
 
-		List<StatValueAO> result = new ArrayList<StatValueAO>();
+		List<StatValueAO> result = new ArrayList<>(11);
 		result.add(new LongValueAO(DOM_MIN.getCaption(), domMinLoadTime));
 		result.add(new LongValueAO(DOM_MAX.getCaption(), domMaxLoadTime));
 		result.add(new DoubleValueAO(DOM_AVG.getCaption(), domAverageLoadTime));

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/predefined/RuntimeStatsDecorator.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/predefined/RuntimeStatsDecorator.java
@@ -74,7 +74,7 @@ public class RuntimeStatsDecorator extends AbstractDecorator {
 		ret.add(new LongValueAO(CAPTIONS[i++], uptime));
 		ret.add(new StringValueAO(CAPTIONS[i++], NumberUtils.makeISO8601TimestampString(starttime)));
 		ret.add(new LongValueAO(CAPTIONS[i++], uptime/1000/60/60));
-		ret.add(new StringValueAO(CAPTIONS[i++], ""+(float)(uptime*100/1000/60/60/24)/100));
+		ret.add(new StringValueAO(CAPTIONS[i++], String.valueOf((float) (uptime * 100 / 1000 / 60 / 60 / 24) / 100)));
 		
 		return ret;
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/DoubleValueAO.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/DoubleValueAO.java
@@ -65,7 +65,7 @@ public class DoubleValueAO extends StatValueAO {
 			doubleValue = aValue;
 		
 		double floatingPart = doubleValue - (int)doubleValue;
-		String fpAsString = ""+floatingPart;
+		String fpAsString = String.valueOf(floatingPart);
 		if (fpAsString.length()>6)
 			fpAsString = fpAsString.substring(0, 5);
 		while(fpAsString.length()<5)
@@ -87,6 +87,6 @@ public class DoubleValueAO extends StatValueAO {
 
 	@Override
 	public String getRawValue() {
-		return ""+doubleValue;
+		return String.valueOf(doubleValue);
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/DoubleValueAO.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/DoubleValueAO.java
@@ -37,6 +37,9 @@ package net.anotheria.moskito.core.decorators.value;
 import net.anotheria.util.BasicComparable;
 import net.anotheria.util.sorter.IComparable;
 
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
 /**
  * Stat value bean for double values.
  * @author lrosenberg.
@@ -63,16 +66,11 @@ public class DoubleValueAO extends StatValueAO {
 			doubleValue = ((double)Math.round(aValue * 1000)) / 1000;
 		else
 			doubleValue = aValue;
-		
-		double floatingPart = doubleValue - (int)doubleValue;
-		String fpAsString = String.valueOf(floatingPart);
-		if (fpAsString.length()>6)
-			fpAsString = fpAsString.substring(0, 5);
-		while(fpAsString.length()<5)
-			fpAsString += "0";
-		doubleAsString = (int)doubleValue+"."+fpAsString.substring(2);
+
+		DecimalFormat decimalFormat = new DecimalFormat("0.000");
+		doubleAsString = decimalFormat.format(doubleValue);
 	}
-	
+
 	@Override public String getValue(){
 		return doubleAsString;
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/LongValueAO.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/LongValueAO.java
@@ -59,7 +59,7 @@ public class LongValueAO extends StatValueAO {
 	}
 	
 	@Override public String getValue(){
-		return longValue == Long.MAX_VALUE || longValue== Long.MIN_VALUE ? "NoR" : ""+NumberUtils.getDotedNumberUS(longValue);
+		return longValue == Long.MAX_VALUE || longValue== Long.MIN_VALUE ? "NoR" : NumberUtils.getDotedNumberUS(longValue);
 	}
 	
 	@Override public int compareTo(IComparable anotherComparable, int ignored) {
@@ -68,7 +68,7 @@ public class LongValueAO extends StatValueAO {
 	
 	@Override
 	public String getRawValue() {
-		return ""+longValue;
+		return String.valueOf(longValue);
 	}
 
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/StatCaptionBean.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/StatCaptionBean.java
@@ -120,7 +120,7 @@ public class StatCaptionBean {
 	 * @return
 	 */
 	public static final String getJsVariableName(String caption){
-		return "v"+StringUtils.removeChars(caption, TO_REMOVE);
+		return 'v' +StringUtils.removeChars(caption, TO_REMOVE);
 		
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/EntryCountLimitedOnDemandStatsProducer.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/EntryCountLimitedOnDemandStatsProducer.java
@@ -69,7 +69,7 @@ public class EntryCountLimitedOnDemandStatsProducer<S extends IStats> extends On
 	}
 	
 	@Override public String toString(){
-		return super.toString()+" ("+getCachedStatsList().size()+" / "+limit+")";
+		return super.toString()+" ("+getCachedStatsList().size()+" / "+limit+ ')';
 	}
 	
 	

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/EntryCountLimitedOnDemandStatsProducer.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/EntryCountLimitedOnDemandStatsProducer.java
@@ -46,7 +46,7 @@ public class EntryCountLimitedOnDemandStatsProducer<S extends IStats> extends On
 	 */
 	private int limit;
 
-	public EntryCountLimitedOnDemandStatsProducer(String aProducerId, String aCategory, String aSubsystem, IOnDemandStatsFactory aStatsFactory, int aLimit){
+	public EntryCountLimitedOnDemandStatsProducer(String aProducerId, String aCategory, String aSubsystem, IOnDemandStatsFactory<S> aStatsFactory, int aLimit){
 		super(aProducerId, aCategory, aSubsystem, aStatsFactory);
 		limit = aLimit;
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/MoskitoInvokationProxy.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/MoskitoInvokationProxy.java
@@ -34,6 +34,7 @@
  */	
 package net.anotheria.moskito.core.dynamic;
 
+import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 
@@ -78,7 +79,7 @@ import java.util.List;
  * @author lrosenberg
  *
  */
-public class MoskitoInvokationProxy implements InvocationHandler{
+public class MoskitoInvokationProxy<S extends IStats> implements InvocationHandler{
 	/**
 	 * Supported interfaces.
 	 */
@@ -101,7 +102,7 @@ public class MoskitoInvokationProxy implements InvocationHandler{
 	/**
 	 * Producer for the stats which is learning the methods on the fly.
 	 */
-	private OnDemandStatsProducer producer;
+	private OnDemandStatsProducer<S> producer;
 	
 	/**
 	 * Creates a new MoskitoInvocationProxy with given implementation, handler and stats factory, and interfaces to monitor.
@@ -113,14 +114,14 @@ public class MoskitoInvokationProxy implements InvocationHandler{
 	 * @param subsystem the key/name/id for the monitored i.e. user,shop,messaging
 	 * @param interfaces interfaces which can be called from outside, i.e. MyService
 	 */
-	public MoskitoInvokationProxy(Object anImplementation, IOnDemandCallHandler aHandler, IOnDemandStatsFactory factory, String producerId, String category, String subsystem, Class<?>... interfaces ){
+	public MoskitoInvokationProxy(Object anImplementation, IOnDemandCallHandler aHandler, IOnDemandStatsFactory<S> factory, String producerId, String category, String subsystem, Class<?>... interfaces ){
 		if (interfaces.length==0)
 			throw new RuntimeException("No interfaces specified!");
 		implementation = anImplementation;
 		supportedInterfaces = interfaces;
 		
 		handler = aHandler;
-		producer = new OnDemandStatsProducer(producerId, category, subsystem, factory);
+		producer = new OnDemandStatsProducer<>(producerId, category, subsystem, factory);
 		producer.setTracingSupported(true);
 		
 		ProducerRegistryFactory.getProducerRegistryInstance().registerProducer(producer);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/MoskitoInvokationProxy.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/MoskitoInvokationProxy.java
@@ -161,7 +161,7 @@ public class MoskitoInvokationProxy implements InvocationHandler{
 	 * Looks up all possible exceptions.
 	 */
 	private void guessExceptions(){
-		List<Class<?>> tmpExceptionList = new ArrayList<Class<?>>();
+		List<Class<?>> tmpExceptionList = new ArrayList<>();
 		for (Class<?> c:supportedInterfaces){
 			Method[] methods = c.getDeclaredMethods();
 			for (Method m:methods){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/MoskitoInvokationProxy.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/MoskitoInvokationProxy.java
@@ -154,7 +154,7 @@ public class MoskitoInvokationProxy implements InvocationHandler{
 	
 	private static String guessProducerId(Object implementation){
 		String className = implementation.getClass().getName();
-		return className.substring(className.lastIndexOf(".")+1);
+		return className.substring(className.lastIndexOf('.')+1);
 	}
 	
 	/**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducer.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducer.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -77,7 +78,7 @@ public class OnDemandStatsProducer<S extends IStats> implements IStatsProducer<S
 	/**
 	 * A map where all stat and their ids (strings) are being stored.
 	 */
-	private final ConcurrentHashMap<String,S> stats;
+	private final ConcurrentMap<String,S> stats;
 	
 	/**
 	 * A fast access variable for default (cumulated) stats.
@@ -123,7 +124,7 @@ public class OnDemandStatsProducer<S extends IStats> implements IStatsProducer<S
 		if (factory==null)
 			throw new IllegalArgumentException("Null factory is not allowed.");
 		
-		stats = new ConcurrentHashMap<String,S>();
+		stats = new ConcurrentHashMap<>();
 		_cachedStatsList = new CopyOnWriteArrayList<S>();
 		
 		try{

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducer.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducer.java
@@ -175,7 +175,7 @@ public class OnDemandStatsProducer<S extends IStats> implements IStatsProducer<S
 	}
 	
 	@Override public String toString(){
-		return "OnDemandProducer ("+getProducerNameExtension()+"): "+getProducerId()+":"+getSubsystem()+":"+getCategory();
+		return "OnDemandProducer ("+getProducerNameExtension()+"): "+getProducerId()+ ':' +getSubsystem()+ ':' +getCategory();
 	}
 	
 	/**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
@@ -25,7 +25,7 @@ public class ProxyUtils {
 	/**
 	 * Internal storage for instance counters.
 	 */
-	private static ConcurrentMap<String,AtomicInteger> instanceCounters = new ConcurrentHashMap<String, AtomicInteger>();
+	private static final ConcurrentMap<String,AtomicInteger>  instanceCounters = new ConcurrentHashMap<>();
 	/**
 	 * Creates a new proxied instance for an existing implementation.
 	 * @param <T> interface type.
@@ -41,14 +41,8 @@ public class ProxyUtils {
 	public static <T> T createInstance(T impl, String name, String category, String subsystem, IOnDemandCallHandler handler, IOnDemandStatsFactory statsFactory, Class<T> interf, Class<?>... additionalInterfaces){
 		if (name==null)
 			name = extractName(interf);
-		
-		Class<?>[] interfacesParameter = new Class<?>[additionalInterfaces==null ? 1 : 1+additionalInterfaces.length];
-		interfacesParameter[0] = interf;
-		if (additionalInterfaces!=null){
-			for (int i=0; i<additionalInterfaces.length; i++){
-				interfacesParameter[i+1] = additionalInterfaces[i];
-			}
-		}
+
+		Class<?>[] interfacesParameter = mergeInterfaces(interf, additionalInterfaces);
 		
 		MoskitoInvokationProxy proxy = new MoskitoInvokationProxy(
 				impl,
@@ -63,7 +57,18 @@ public class ProxyUtils {
 		@SuppressWarnings("unchecked") T ret = (T) proxy.createProxy();
 		return ret;
 	}
-	
+
+	public static <T> Class<?>[] mergeInterfaces(Class<T> interf, Class<?>... additionalInterfaces) {
+		Class<?>[] interfacesParameter = new Class<?>[additionalInterfaces==null ? 1 : 1 + additionalInterfaces.length];
+		interfacesParameter[0] = interf;
+		if (additionalInterfaces!=null){
+			for (int i=0; i<additionalInterfaces.length; i++){
+				interfacesParameter[i+1] = additionalInterfaces[i];
+			}
+		}
+		return interfacesParameter;
+	}
+
 	/**
 	 * Creates a monitored proxy instance for a service. Service in this context means, that the ServiceStatsCallHandler and ServiceStatsFactory are used.
 	 * @param <T> the server interface.
@@ -149,7 +154,7 @@ public class ProxyUtils {
 	 * @param clazz the target clazz..
 	 * @return
 	 */
-	private static final String extractName(Class<?> clazz){
+	private static String extractName(Class<?> clazz){
 		String name = clazz.getName();
 		if (name==null)
 			name = "";

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
@@ -58,7 +58,15 @@ public class ProxyUtils {
 		return ret;
 	}
 
-	public static <T> Class<?>[] mergeInterfaces(Class<T> interf, Class<?>... additionalInterfaces) {
+	/**
+	 * Creates an array consisting of an interface class (first parameter) and optionally some more additional interface
+	 * classes.
+	 *
+	 * @param interf The interface that will be positioned as the first element of the array
+	 * @param additionalInterfaces Optional additional interfaces, that will be appended to the array
+     * @return an array containing the interface and some more interfaces if given
+     */
+	public static Class<?>[] mergeInterfaces(Class<?> interf, Class<?>... additionalInterfaces) {
 		Class<?>[] interfacesParameter = new Class<?>[additionalInterfaces==null ? 1 : 1 + additionalInterfaces.length];
 		interfacesParameter[0] = interf;
 		if (additionalInterfaces!=null){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
@@ -25,7 +25,7 @@ public class ProxyUtils {
 	/**
 	 * Internal storage for instance counters.
 	 */
-	private static final ConcurrentMap<String,AtomicInteger>  instanceCounters = new ConcurrentHashMap<>();
+	private static final ConcurrentMap<String,AtomicInteger> instanceCounters = new ConcurrentHashMap<>();
 	/**
 	 * Creates a new proxied instance for an existing implementation.
 	 * @param <T> interface type.

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
@@ -48,7 +48,7 @@ public class ProxyUtils {
 				impl,
 				handler,
 				statsFactory,
-				name+"-"+getInstanceCounter(name),
+				name+ '-' +getInstanceCounter(name),
 				category,
 				subsystem,
 				interfacesParameter

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/dynamic/ProxyUtils.java
@@ -62,9 +62,7 @@ public class ProxyUtils {
 		Class<?>[] interfacesParameter = new Class<?>[additionalInterfaces==null ? 1 : 1 + additionalInterfaces.length];
 		interfacesParameter[0] = interf;
 		if (additionalInterfaces!=null){
-			for (int i=0; i<additionalInterfaces.length; i++){
-				interfacesParameter[i+1] = additionalInterfaces[i];
-			}
+			System.arraycopy(additionalInterfaces, 0, interfacesParameter, 1, additionalInterfaces.length);
 		}
 		return interfacesParameter;
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/helper/AbstractTieable.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/helper/AbstractTieable.java
@@ -29,7 +29,7 @@ public abstract class AbstractTieable<D extends TieableDefinition> implements Ti
 	 */
 	protected AbstractTieable(D aDefinition){
 		definition = aDefinition;
-		id = ""+instanceCounter.incrementAndGet();
+		id = String.valueOf(instanceCounter.incrementAndGet());
 
 	}
 	

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableDefinition.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableDefinition.java
@@ -61,7 +61,7 @@ public class TieableDefinition implements Serializable{
 	}
 
 	@Override public String toString(){
-		return getProducerName()+"."+getStatName()+"."+getValueName();
+		return getProducerName()+ '.' +getStatName()+ '.' +getValueName();
 	}
 
 	public String getProducerName() {
@@ -96,7 +96,7 @@ public class TieableDefinition implements Serializable{
 	}
 	
 	public String describe(){
-		return getProducerName()+"."+getStatName()+"."+getValueName()+"/"+getIntervalName()+"/"+getTimeUnit();
+		return getProducerName()+ '.' +getStatName()+ '.' +getValueName()+ '/' +getIntervalName()+ '/' +getTimeUnit();
 	}
 
 	public String getDescription() {

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableRepository.java
@@ -97,7 +97,7 @@ public abstract class TieableRepository<T extends Tieable> implements IProducerR
 				try{
 					tie(t, producer);
 				}catch(Exception e){
-					log.error("notifyProducerRegistered("+producer+")",e );
+					log.error("notifyProducerRegistered("+producer+ ')',e );
 				}
 			}
 		}
@@ -141,7 +141,7 @@ public abstract class TieableRepository<T extends Tieable> implements IProducerR
 		String name = t.getName();
 		int i=1;
 		while( tieables.get(name)!=null){
-			name = t.getName()+"-"+(i++);
+			name = t.getName()+ '-' +(i++);
 		}
 		definition.setName(name);//set net name, in order to prevent name conflicts.
 		tieables.put(t.getName(), t);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableRepository.java
@@ -91,8 +91,7 @@ public abstract class TieableRepository<T extends Tieable> implements IProducerR
 	
 	@Override
 	public void notifyProducerRegistered(IStatsProducer<?> producer) {
-		ArrayList<T> tmpList = new ArrayList<T>();
-		tmpList.addAll(yetUntied);
+		ArrayList<T> tmpList = new ArrayList<T>(yetUntied);
 		for (T t : tmpList){
 			if (t.getDefinition().getProducerName().equals(producer.getProducerId())){
 				try{

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableRepository.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * @param <T>
  */
-public abstract class TieableRepository<T extends Tieable> implements IProducerRegistryListener, IUpdateable {
+public abstract class TieableRepository<T extends Tieable, S extends IStats> implements IProducerRegistryListener<S>, IUpdateable {
 	/**
 	 * Interval listeners.
 	 */
@@ -90,7 +90,7 @@ public abstract class TieableRepository<T extends Tieable> implements IProducerR
 	}
 	
 	@Override
-	public void notifyProducerRegistered(IStatsProducer<?> producer) {
+	public void notifyProducerRegistered(IStatsProducer<S> producer) {
 		ArrayList<T> tmpList = new ArrayList<T>(yetUntied);
 		for (T t : tmpList){
 			if (t.getDefinition().getProducerName().equals(producer.getProducerId())){
@@ -104,7 +104,7 @@ public abstract class TieableRepository<T extends Tieable> implements IProducerR
 	}
 
 	@Override
-	public void notifyProducerUnregistered(IStatsProducer<?> producer) {
+	public void notifyProducerUnregistered(IStatsProducer<S> producer) {
 		//nothing
 	}
 	

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/helper/TieableRepository.java
@@ -26,7 +26,7 @@ public abstract class TieableRepository<T extends Tieable> implements IProducerR
 	/**
 	 * Interval listeners.
 	 */
-	private ConcurrentMap<String, IntervalListener> listeners = new ConcurrentHashMap<String, IntervalListener>();
+	private ConcurrentMap<String, IntervalListener> listeners = new ConcurrentHashMap<>();
 	
 	/**
 	 * Reference to producer registry.
@@ -39,7 +39,7 @@ public abstract class TieableRepository<T extends Tieable> implements IProducerR
 	/**
 	 * Tieables. This map contains already tied tieables.
 	 */
-	private ConcurrentMap<String, T> tieables = new ConcurrentHashMap<String, T>();
+	private ConcurrentMap<String, T> tieables = new ConcurrentHashMap<>();
 	/**
 	 * The listener to the default interval.
 	 */
@@ -54,7 +54,7 @@ public abstract class TieableRepository<T extends Tieable> implements IProducerR
 	/**
 	 * Map that contains names of the tieables maped by ids.
 	 */
-	private ConcurrentMap<String, String> id2nameMapping = new ConcurrentHashMap<String, String>();
+	private ConcurrentMap<String, String> id2nameMapping = new ConcurrentHashMap<>();
 
 
 	public TieableRepository() {

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/journey/Journey.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/journey/Journey.java
@@ -40,7 +40,7 @@ public class Journey {
 		name = aName;
 		createdTimestamp = System.currentTimeMillis();
 		active = true;
-		tracedCalls = new ArrayList<CurrentlyTracedCall>();
+		tracedCalls = new ArrayList<>();
 	}
 	
 	/**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/journey/JourneyManagerImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/journey/JourneyManagerImpl.java
@@ -19,7 +19,7 @@ public class JourneyManagerImpl implements JourneyManager{
 	 * Creates a new JourneyManagerImpl.
 	 */
 	JourneyManagerImpl(){
-		journeys = new ConcurrentHashMap<String, Journey>();
+		journeys = new ConcurrentHashMap<>();
 	}
 	
 	@Override public Journey createJourney(String name) {

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/journey/JourneyManagerImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/journey/JourneyManagerImpl.java
@@ -47,8 +47,7 @@ public class JourneyManagerImpl implements JourneyManager{
 	}
 
 	@Override public List<Journey> getJourneys() {
-		ArrayList<Journey> ret = new ArrayList<Journey>();//do not call journeys size since it will synchronize the map
-		ret.addAll(journeys.values());
+		ArrayList<Journey> ret = new ArrayList<Journey>(journeys.values());//do not call journeys size since it will synchronize the map
 		return ret;
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/plugins/PluginRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/plugins/PluginRepository.java
@@ -114,8 +114,7 @@ public final class PluginRepository {
 	 * @return list of loaded plugins names.
 	 */
 	public List<String> getPluginNames() {
-		ArrayList<String> ret = new ArrayList<String>();
-		ret.addAll(plugins.keySet());
+		ArrayList<String> ret = new ArrayList<String>(plugins.keySet());
 		return ret;
 	}
 
@@ -124,8 +123,7 @@ public final class PluginRepository {
 	 * @return list of loaded plugins.
 	 */
 	public List<MoskitoPlugin> getPlugins() {
-		ArrayList<MoskitoPlugin> ret = new ArrayList<MoskitoPlugin>();
-		ret.addAll(plugins.values());
+		ArrayList<MoskitoPlugin> ret = new ArrayList<MoskitoPlugin>(plugins.values());
 		return ret;
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/plugins/PluginRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/plugins/PluginRepository.java
@@ -27,12 +27,12 @@ public final class PluginRepository {
 	/**
 	 * Plugins.
 	 */
-	private ConcurrentMap<String, MoskitoPlugin> plugins = new ConcurrentHashMap<String, MoskitoPlugin>();
+	private ConcurrentMap<String, MoskitoPlugin> plugins = new ConcurrentHashMap<>();
 
 	/**
 	 * Cached configs.
 	 */
-	private ConcurrentMap<String,PluginConfig> configs = new ConcurrentHashMap<String,PluginConfig>();
+	private ConcurrentMap<String,PluginConfig> configs = new ConcurrentHashMap<>();
 
 
 	/**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/AbstractMemoryPoolStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/AbstractMemoryPoolStats.java
@@ -37,7 +37,7 @@ public abstract class AbstractMemoryPoolStats extends AbstractStats implements I
 	}
 	
 	@Override public String getValueByNameAsString(String valueName, String intervalName, TimeUnit timeUnit){
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 		

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/AbstractMemoryPoolStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/AbstractMemoryPoolStats.java
@@ -42,27 +42,27 @@ public abstract class AbstractMemoryPoolStats extends AbstractStats implements I
 		valueName = valueName.toLowerCase();
 		
 		if (valueName.equals("init"))
-			return ""+getInit(intervalName);
+			return String.valueOf(getInit(intervalName));
 		if (valueName.equals("min_used"))
-			return ""+getMinUsed(intervalName);
+			return String.valueOf(getMinUsed(intervalName));
 		if (valueName.equals("used"))
-			return ""+getUsed(intervalName);
+			return String.valueOf(getUsed(intervalName));
 		if (valueName.equals("used mb"))
-			return ""+getUsed(intervalName)/MB;
+			return String.valueOf(getUsed(intervalName) / MB);
 		if (valueName.equals("max_used"))
-			return ""+getMaxUsed(intervalName);
+			return String.valueOf(getMaxUsed(intervalName));
 		if (valueName.equals("min_commited"))
-			return ""+getMinCommited(intervalName);
+			return String.valueOf(getMinCommited(intervalName));
 		if (valueName.equals("commited"))
-			return ""+getCommited(intervalName);
+			return String.valueOf(getCommited(intervalName));
 		if (valueName.equals("max_commited"))
-			return ""+getMaxCommited(intervalName);
+			return String.valueOf(getMaxCommited(intervalName));
 		if (valueName.equals("max"))
-			return ""+getMax(intervalName);
+			return String.valueOf(getMax(intervalName));
 		if (valueName.equals("free"))
-			return ""+getFree(intervalName);
+			return String.valueOf(getFree(intervalName));
 		if (valueName.equals("free mb"))
-			return ""+getFree(intervalName)/MB;
+			return String.valueOf(getFree(intervalName) / MB);
 		
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/CacheStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/CacheStats.java
@@ -307,25 +307,25 @@ public class CacheStats extends AbstractStats {
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 		if (valueName.equals("req"))
-			return ""+requests.getValueAsLong(intervalName);
+			return String.valueOf(requests.getValueAsLong(intervalName));
 		if (valueName.equals("hit"))
-			return ""+hits.getValueAsLong(intervalName);
+			return String.valueOf(hits.getValueAsLong(intervalName));
 		if (valueName.equals("hr"))
-			return ""+getHitRatio(intervalName);
+			return String.valueOf(getHitRatio(intervalName));
 		if (valueName.equals("wr"))
-			return ""+writes.getValueAsLong(intervalName);
+			return String.valueOf(writes.getValueAsLong(intervalName));
 		if (valueName.equals("gc"))
-			return ""+garbageCollected.getValueAsLong(intervalName);
+			return String.valueOf(garbageCollected.getValueAsLong(intervalName));
 		if (valueName.equals("ro"))
-			return ""+rolloverCount.getValueAsLong(intervalName);
+			return String.valueOf(rolloverCount.getValueAsLong(intervalName));
 		if (valueName.equals("fu"))
-			return ""+cacheFullCount.getValueAsLong(intervalName);
+			return String.valueOf(cacheFullCount.getValueAsLong(intervalName));
 		if (valueName.equals("ex"))
-			return ""+expiredCount.getValueAsLong(intervalName);
+			return String.valueOf(expiredCount.getValueAsLong(intervalName));
 		if (valueName.equals("del"))
-			return ""+deletes.getValueAsLong(intervalName);
+			return String.valueOf(deletes.getValueAsLong(intervalName));
 		if (valueName.equals("fi"))
-			return ""+filteredCount.getValueAsLong(intervalName);
+			return String.valueOf(filteredCount.getValueAsLong(intervalName));
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/CacheStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/CacheStats.java
@@ -303,7 +303,7 @@ public class CacheStats extends AbstractStats {
 	}
 
 	@Override public String getValueByNameAsString(String valueName, String intervalName, TimeUnit timeUnit){
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 		if (valueName.equals("req"))

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MBeanStatsList.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MBeanStatsList.java
@@ -498,11 +498,11 @@ public class MBeanStatsList extends ArrayList<GenericStats> {
      * @return {@link Collection} of {@link MBeanAttributeInfo}s
      */
     private Collection<MBeanAttributeInfo> getAttributes() {
-        final Collection<MBeanAttributeInfo> attributes = new ArrayList<MBeanAttributeInfo>();
-
         try {
             final MBeanAttributeInfo[] all = server.getMBeanInfo(mbean).getAttributes();
+            final Collection<MBeanAttributeInfo> attributes = new ArrayList<>(all.length);
             Collections.addAll(attributes, all);
+            return attributes;
         } catch (final IntrospectionException e) {
             LOGGER.info("unable to determine attributes of MBean: " + mbean, e);
 
@@ -513,7 +513,7 @@ public class MBeanStatsList extends ArrayList<GenericStats> {
             LOGGER.info("unable to determine attributes of MBean: " + mbean, e);
         }
 
-        return attributes;
+        return new ArrayList<>(0);
     }
 
     /**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MBeanStatsList.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MBeanStatsList.java
@@ -18,6 +18,7 @@ import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.TimerTask;
 
 import static net.anotheria.moskito.core.util.MBeanProducerFactory.normalize;
@@ -501,11 +502,7 @@ public class MBeanStatsList extends ArrayList<GenericStats> {
 
         try {
             final MBeanAttributeInfo[] all = server.getMBeanInfo(mbean).getAttributes();
-
-            for (final MBeanAttributeInfo attribute : all) {
-                attributes.add(attribute);
-            }
-
+            Collections.addAll(attributes, all);
         } catch (final IntrospectionException e) {
             LOGGER.info("unable to determine attributes of MBean: " + mbean, e);
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MemoryStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MemoryStats.java
@@ -72,7 +72,7 @@ public class MemoryStats extends AbstractStats {
 
 	@Override
 	public String getValueByNameAsString(String valueName, String intervalName, TimeUnit timeUnit) {
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MemoryStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MemoryStats.java
@@ -77,19 +77,19 @@ public class MemoryStats extends AbstractStats {
 		valueName = valueName.toLowerCase();
 
 		if (valueName.equals("current") || valueName.equals("cur"))
-			return ""+getCurrent(intervalName);
+			return String.valueOf(getCurrent(intervalName));
 		if (valueName.equals("current mb") || valueName.equals("cur mb"))
-			return ""+(getCurrent(intervalName)/MB);
+			return String.valueOf(getCurrent(intervalName) / MB);
 
 		if (valueName.equals("min") )
-			return ""+getMin(intervalName);
+			return String.valueOf(getMin(intervalName));
 		if (valueName.equals("min mb"))
-			return ""+(getMin(intervalName)/MB);
+			return String.valueOf(getMin(intervalName) / MB);
 
 		if (valueName.equals("max") )
-			return ""+getMax(intervalName);
+			return String.valueOf(getMax(intervalName));
 		if (valueName.equals("max mb"))
-			return ""+(getMax(intervalName)/MB);
+			return String.valueOf(getMax(intervalName) / MB);
 
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/OSStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/OSStats.java
@@ -112,29 +112,29 @@ public class OSStats extends AbstractStats {
 
 		
 		if (valueName.equals("free memory") || valueName.equals("free"))
-			return ""+getFreePhysicalMemory(intervalName);
+			return String.valueOf(getFreePhysicalMemory(intervalName));
 		if (valueName.equals("total memory") || valueName.equals("total"))
-			return ""+getTotalPhysicalMemory(intervalName);
+			return String.valueOf(getTotalPhysicalMemory(intervalName));
 		if (valueName.equals("free memory mb") || valueName.equals("free mb"))
-			return ""+getFreePhysicalMemory(intervalName)/MB;
+			return String.valueOf(getFreePhysicalMemory(intervalName) / MB);
 		if (valueName.equals("total memory mb") || valueName.equals("total mb"))
-			return ""+getTotalPhysicalMemory(intervalName)/MB;
+			return String.valueOf(getTotalPhysicalMemory(intervalName) / MB);
 		
 		if (valueName.equals("openfiles") || valueName.equals("open files"))
-			return ""+getOpenFiles(intervalName);
+			return String.valueOf(getOpenFiles(intervalName));
 		if (valueName.equals("minopenfiles") || valueName.equals("min open files"))
-			return ""+getMinOpenFiles(intervalName);
+			return String.valueOf(getMinOpenFiles(intervalName));
 		if (valueName.equals("maxopenfiles") || valueName.equals("max open files"))
-			return ""+getMaxOpenFiles(intervalName);
+			return String.valueOf(getMaxOpenFiles(intervalName));
 		if (valueName.equals("maxsupportedopenfiles") || valueName.equals("max supported open files"))
-			return ""+getMaxSupportedOpenFiles(intervalName);
+			return String.valueOf(getMaxSupportedOpenFiles(intervalName));
 
 		if (valueName.equals("cputime") || valueName.equals("cpu time"))
-			return ""+getProcessCPUTime(intervalName);
+			return String.valueOf(getProcessCPUTime(intervalName));
 		if (valueName.equals("total cputime") || valueName.equals("total cpu time") || valueName.equals("totalcputime") )
-			return ""+getProcessTotalCPUTime(intervalName);
+			return String.valueOf(getProcessTotalCPUTime(intervalName));
 		if (valueName.equals("processors"))
-			return ""+getProcessors(intervalName);
+			return String.valueOf(getProcessors(intervalName));
 		
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/PageInBrowserStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/PageInBrowserStats.java
@@ -284,7 +284,7 @@ public class PageInBrowserStats extends AbstractStats {
 	 * @return formatted stats string
 	 */
 	private String toFormattedStatsString(final PageInBrowserStatsValueName valueName, final String value) {
-		return " " + valueName.getValueName() + ": " + value;
+		return ' ' + valueName.getValueName() + ": " + value;
 	}
 
 	@Override

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueueStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueueStats.java
@@ -71,7 +71,7 @@ public class QueueStats extends AbstractStats {
 		}
 		
 		public String getStatLabel(){
-			return " " + statName + ": ";
+			return ' ' + statName + ": ";
 		}
 		
 		public static List<String> getStatNames(){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueueStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueueStats.java
@@ -283,34 +283,34 @@ public class QueueStats extends AbstractStats {
 			throw new AssertionError("Value name can not be empty");
 		
 		if (valueName.equalsIgnoreCase(StatDef.REQUESTS.getStatName()))
-				return ""+getRequests(intervalName);
+				return String.valueOf(getRequests(intervalName));
 				
 		if (valueName.equalsIgnoreCase(StatDef.ENQUEUED.getStatName()))
-			return ""+getEnqueued(intervalName);
+			return String.valueOf(getEnqueued(intervalName));
 		
 		if (valueName.equalsIgnoreCase(StatDef.DEQUEUED.getStatName()))
-			return ""+getDequeued(intervalName);
+			return String.valueOf(getDequeued(intervalName));
 		
 		if (valueName.equalsIgnoreCase(StatDef.FULL.getStatName()))
-			return ""+getFull(intervalName);
+			return String.valueOf(getFull(intervalName));
 		
 		if (valueName.equalsIgnoreCase(StatDef.EMPTY.getStatName()))
-			return ""+getEmpty(intervalName);
+			return String.valueOf(getEmpty(intervalName));
 		
 		if (valueName.equalsIgnoreCase(StatDef.TOTAL_SIZE.getStatName()))
-			return ""+getTotalSize(intervalName);
+			return String.valueOf(getTotalSize(intervalName));
 		
 		if (valueName.equalsIgnoreCase(StatDef.ENQUEUE_LAST_SIZE.getStatName()))
-			return ""+getOnRequestLastSize(intervalName);
+			return String.valueOf(getOnRequestLastSize(intervalName));
 		
 		if (valueName.equalsIgnoreCase(StatDef.ENQUEUE_MIN_SIZE.getStatName()))
-			return ""+getOnRequestMinSize(intervalName);
+			return String.valueOf(getOnRequestMinSize(intervalName));
 		
 		if (valueName.equalsIgnoreCase(StatDef.ENQUEUE_MAX_SIZE.getStatName()))
-			return ""+getOnRequestMaxSize(intervalName);
+			return String.valueOf(getOnRequestMaxSize(intervalName));
 		
 		if (valueName.equals(StatDef.ENQUEUE_AVERAGE_SIZE.getStatName()))
-			return ""+getOnRequestAverageSize(intervalName);
+			return String.valueOf(getOnRequestAverageSize(intervalName));
 
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueueStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueueStats.java
@@ -279,7 +279,7 @@ public class QueueStats extends AbstractStats {
 
 	@Override public String getValueByNameAsString(String valueName, String intervalName, TimeUnit timeUnit){
 		
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		
 		if (valueName.equalsIgnoreCase(StatDef.REQUESTS.getStatName()))

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueuingSystemStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueuingSystemStats.java
@@ -368,7 +368,7 @@ public class QueuingSystemStats extends AbstractStats {
 
 	@Override public String getValueByNameAsString(String valueName, String intervalName, TimeUnit timeUnit){
 		
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		
 		if (valueName.equals(StatDef.SERVERS_SIZE.getStatName()))

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueuingSystemStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueuingSystemStats.java
@@ -91,7 +91,7 @@ public class QueuingSystemStats extends AbstractStats {
 		}
 		
 		public String getStatLabel(){
-			return " " + statName + ": ";
+			return ' ' + statName + ": ";
 		}
 		
 		public static List<String> getStatNames(){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueuingSystemStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/QueuingSystemStats.java
@@ -326,21 +326,21 @@ public class QueuingSystemStats extends AbstractStats {
 		if (minTime == Constants.MIN_TIME_DEFAULT)
 			return "NoR";
 			
-		return "" + timeUnit.transformNanos(minTime);
+		return String.valueOf(timeUnit.transformNanos(minTime));
 	}
 	
 	private String transformMaxTimeNanos(long maxTime, TimeUnit timeUnit){
 		if (maxTime == Constants.MAX_TIME_DEFAULT)
 			return "NoR";
 			
-		return "" + timeUnit.transformNanos(maxTime);
+		return String.valueOf(timeUnit.transformNanos(maxTime));
 	}
 	
 	private String transformAverageTimeNanos(long maxTime, TimeUnit timeUnit){
 		if (maxTime == Constants.AVERAGE_TIME_DEFAULT)
 			return "NoR";
 			
-		return "" + timeUnit.transformNanos(maxTime);
+		return String.valueOf(timeUnit.transformNanos(maxTime));
 	}
 	
 	@Override public String toStatsString(String intervalName, TimeUnit timeUnit) {
@@ -372,28 +372,28 @@ public class QueuingSystemStats extends AbstractStats {
 			throw new AssertionError("Value name can not be empty");
 		
 		if (valueName.equals(StatDef.SERVERS_SIZE.getStatName()))
-			return ""+getServersSize(intervalName);
+			return String.valueOf(getServersSize(intervalName));
 		
 		if (valueName.equals(StatDef.QUEUE_SIZE.getStatName()))
-			return ""+getQueueSize(intervalName);
+			return String.valueOf(getQueueSize(intervalName));
 		
 		if (valueName.equals(StatDef.ARRIVED.getStatName()))
-			return ""+getArrived(intervalName);
+			return String.valueOf(getArrived(intervalName));
 		
 		if (valueName.equals(StatDef.SERVICED.getStatName()))
-			return ""+getServiced(intervalName);
+			return String.valueOf(getServiced(intervalName));
 		
 		if (valueName.equals(StatDef.ERRORS.getStatName()))
-			return ""+getErrors(intervalName);
+			return String.valueOf(getErrors(intervalName));
 		
 		if (valueName.equals(StatDef.WAITED.getStatName()))
-			return ""+getWaited(intervalName);
+			return String.valueOf(getWaited(intervalName));
 		
 		if (valueName.equals(StatDef.THROWN_AWAY.getStatName()))
-			return ""+getThrowedAway(intervalName);
+			return String.valueOf(getThrowedAway(intervalName));
 		
 		if (valueName.equals(StatDef.WAITING_TIME.getStatName()))
-			return ""+timeUnit.transformNanos(getWaitingTime(intervalName));
+			return String.valueOf(timeUnit.transformNanos(getWaitingTime(intervalName)));
 		
 		if (valueName.equals(StatDef.WAITING_TIME_MIN.getStatName()))
 			return transformMinTimeNanos(getWaitingTimeMin(intervalName), timeUnit);
@@ -405,7 +405,7 @@ public class QueuingSystemStats extends AbstractStats {
 			return transformAverageTimeNanos(getWaitingTimeAverage(intervalName), timeUnit);
 		
 		if (valueName.equals(StatDef.SERVICE_TIME.getStatName()))
-			return ""+timeUnit.transformNanos(getServicingTime(intervalName));
+			return String.valueOf(timeUnit.transformNanos(getServicingTime(intervalName)));
 		
 		if (valueName.equals(StatDef.SERVICE_TIME_MIN.getStatName()))
 			return transformMinTimeNanos(getServicingTimeMin(intervalName), timeUnit);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/RequestOrientedStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/RequestOrientedStats.java
@@ -41,6 +41,7 @@ import net.anotheria.moskito.core.calltrace.TracedCall;
 import net.anotheria.moskito.core.producers.AbstractCallExecution;
 import net.anotheria.moskito.core.producers.AbstractStats;
 import net.anotheria.moskito.core.producers.CallExecution;
+import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.stats.Interval;
 import net.anotheria.moskito.core.stats.StatValue;
 import net.anotheria.moskito.core.stats.TimeUnit;
@@ -525,7 +526,9 @@ public abstract class RequestOrientedStats extends AbstractStats {
 				currentlyTracedCall = tracedCall.callTraced() ? 
 						(CurrentlyTracedCall)tracedCall : null;
 				if (currentlyTracedCall !=null){
-					currentStep = currentlyTracedCall.startStep(callDescription == null ? getName():callDescription);
+					IStatsProducer producer = null;
+					String call = callDescription == null ? getName() : callDescription;
+					currentStep = currentlyTracedCall.startStep(call, producer);
 				}
 			}
 		}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/RequestOrientedStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/RequestOrientedStats.java
@@ -287,7 +287,7 @@ public abstract class RequestOrientedStats extends AbstractStats {
 	}
 	
 	@Override public String getValueByNameAsString(String valueName, String intervalName, TimeUnit timeUnit){
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 		if (valueName.equals("tr") || valueName.equals("req"))

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/RequestOrientedStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/RequestOrientedStats.java
@@ -291,25 +291,25 @@ public abstract class RequestOrientedStats extends AbstractStats {
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 		if (valueName.equals("tr") || valueName.equals("req"))
-			return "" + totalRequests.getValueAsLong(intervalName);
+			return String.valueOf(totalRequests.getValueAsLong(intervalName));
 		if (valueName.equals("tt")|| valueName.equals("time") || valueName.equals("totaltime"))
-			return "" + timeUnit.transformNanos(totalTime.getValueAsLong(intervalName));
+			return String.valueOf(timeUnit.transformNanos(totalTime.getValueAsLong(intervalName)));
 		if (valueName.equals("cr"))
-			return "" + currentRequests.getValueAsLong(intervalName);
+			return String.valueOf(currentRequests.getValueAsLong(intervalName));
 		if (valueName.equals("mcr"))
-			return "" + maxCurrentRequests.getValueAsLong(intervalName);
+			return String.valueOf(maxCurrentRequests.getValueAsLong(intervalName));
 		if (valueName.equals("err"))
-			return "" + errors.getValueAsLong(intervalName);
+			return String.valueOf(errors.getValueAsLong(intervalName));
 		if (valueName.equals("last"))
-			return "" + timeUnit.transformNanos(lastRequest.getValueAsLong(intervalName));
+			return String.valueOf(timeUnit.transformNanos(lastRequest.getValueAsLong(intervalName)));
 		if (valueName.equals("min"))
-			return "" + timeUnit.transformNanos(minTime.getValueAsLong(intervalName));
+			return String.valueOf(timeUnit.transformNanos(minTime.getValueAsLong(intervalName)));
 		if (valueName.equals("max"))
-			return "" + timeUnit.transformNanos(maxTime.getValueAsLong(intervalName));
+			return String.valueOf(timeUnit.transformNanos(maxTime.getValueAsLong(intervalName)));
 		if (valueName.equals("avg"))
-			return "" + getAverageRequestDuration(intervalName, timeUnit);
+			return String.valueOf(getAverageRequestDuration(intervalName, timeUnit));
 		if (valueName.equals("erate") || valueName.equals("errorrate") || valueName.equals("errrate"))
-			return "" + getErrorRate(intervalName);
+			return String.valueOf(getErrorRate(intervalName));
 
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/RuntimeStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/RuntimeStats.java
@@ -83,9 +83,9 @@ public class RuntimeStats extends AbstractStats {
 		if (valueName.equals("process") || valueName.equals("name") || valueName.equals("processname"))
 			return processName.getValueAsString(intervalName);
 		if (valueName.equals("starttime"))
-			return ""+getStartTime(intervalName);
+			return String.valueOf(getStartTime(intervalName));
 		if (valueName.equals("uptime"))
-			return ""+getUptime(intervalName);
+			return String.valueOf(getUptime(intervalName));
 		
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ServiceStatsCallHandler.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ServiceStatsCallHandler.java
@@ -126,7 +126,7 @@ public class ServiceStatsCallHandler implements IOnDemandCallHandler {
 				try{
 					currentStep.appendToCall(" = "+TracingUtil.parameter2string(ret));
 				}catch(Throwable t){
-					currentStep.appendToCall(" = ERR: "+t.getMessage()+" ("+t.getClass()+")");
+					currentStep.appendToCall(" = ERR: "+t.getMessage()+" ("+t.getClass()+ ')');
 				}
 			}
 			if (currentTrace !=null)

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ServiceStatsCallHandlerWithCallSysout.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ServiceStatsCallHandlerWithCallSysout.java
@@ -76,7 +76,7 @@ public class ServiceStatsCallHandlerWithCallSysout implements IOnDemandCallHandl
 	}
 
 	@Override public Object invoke(Object target, Object[] args, Method method, Class<?> targetClass, Class<?>[] declaredExceptions, IStats aDefaultStats, IStats aMethodStats, IStatsProducer producer) throws Throwable {
-		String callId = overallCallCounter.incrementAndGet()+"-"+instanceId + "-"+callCounter.incrementAndGet();
+		String callId = overallCallCounter.incrementAndGet()+"-"+instanceId + '-' +callCounter.incrementAndGet();
 		
 		ServiceStats defaultStats = (ServiceStats)aDefaultStats;
 		ServiceStats methodStats = (ServiceStats)aMethodStats;
@@ -128,14 +128,14 @@ public class ServiceStatsCallHandlerWithCallSysout implements IOnDemandCallHandl
 			//System.out.println("exception of class: "+e.getCause()+" is thrown");
 			if (currentElement!=null)
 				currentElement.setAborted();
-			debugOutPostCall.append("ERR (E) ").append(e.getCause().getMessage()).append(" ").append(e.getCause().toString());
+			debugOutPostCall.append("ERR (E) ").append(e.getCause().getMessage()).append(' ').append(e.getCause().toString());
 			throw e.getCause();
 		}catch(Throwable t){
 			defaultStats.notifyError();
 			methodStats.notifyError();
 			if (currentElement!=null)
 				currentElement.setAborted();
-			debugOutPostCall.append("ERR (T) ").append(t.getMessage()).append(" ").append(t.toString());
+			debugOutPostCall.append("ERR (T) ").append(t.getMessage()).append(' ').append(t.toString());
 			throw t;
 		}finally{
 			defaultStats.notifyRequestFinished();

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ServletStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ServletStats.java
@@ -185,11 +185,11 @@ public class ServletStats extends RequestOrientedStats{
 		valueName = valueName.toLowerCase();
 
 		if (valueName.equals("ioexc"))
-			return "" + ioExceptions.getValueAsLong(intervalName); 
+			return String.valueOf(ioExceptions.getValueAsLong(intervalName));
 		if (valueName.equals("seexc"))
-			return "" + servletExceptions.getValueAsLong(intervalName);
+			return String.valueOf(servletExceptions.getValueAsLong(intervalName));
 		if (valueName.equals("rtexc"))
-			return "" + runtimeExceptions.getValueAsLong(intervalName);
+			return String.valueOf(runtimeExceptions.getValueAsLong(intervalName));
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ServletStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ServletStats.java
@@ -180,7 +180,7 @@ public class ServletStats extends RequestOrientedStats{
 	@Override
 	public String getValueByNameAsString(String valueName, String intervalName,
 			TimeUnit timeUnit) {
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ThreadCountStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ThreadCountStats.java
@@ -130,15 +130,15 @@ public class ThreadCountStats extends AbstractStats {
 		valueName = valueName.toLowerCase();
 		
 		if (valueName.equals("cur") || valueName.equals("current"))
-			return ""+getCurrent(intervalName);
+			return String.valueOf(getCurrent(intervalName));
 		if (valueName.equals("min") || valueName.equals("mincurrent") || valueName.equals("min cur"))
-			return ""+getMinCurrent(intervalName);
+			return String.valueOf(getMinCurrent(intervalName));
 		if (valueName.equals("max") || valueName.equals("maxcurrent") || valueName.equals("max cur"))
-			return ""+getMaxCurrent(intervalName);
+			return String.valueOf(getMaxCurrent(intervalName));
 		if (valueName.equals("started"))
-			return ""+getStarted(intervalName);
+			return String.valueOf(getStarted(intervalName));
 		if (valueName.equals("daemon"))
-			return ""+getDaemon(intervalName);
+			return String.valueOf(getDaemon(intervalName));
 		
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ThreadStateStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ThreadStateStats.java
@@ -88,7 +88,7 @@ public class ThreadStateStats extends AbstractStats {
 
 	@Override
 	public String getValueByNameAsString(String valueName, String intervalName, TimeUnit timeUnit) {
-		if (valueName==null || valueName.equals(""))
+		if (valueName==null || valueName.isEmpty())
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 		if (valueName.equals("cur") || valueName.equals("current"))

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ThreadStateStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/ThreadStateStats.java
@@ -92,11 +92,11 @@ public class ThreadStateStats extends AbstractStats {
 			throw new AssertionError("Value name can not be empty");
 		valueName = valueName.toLowerCase();
 		if (valueName.equals("cur") || valueName.equals("current"))
-			return ""+getCurrent(intervalName);
+			return String.valueOf(getCurrent(intervalName));
 		if (valueName.equals("min"))
-			return ""+getMin(intervalName);
+			return String.valueOf(getMin(intervalName));
 		if (valueName.equals("max"))
-			return ""+getMax(intervalName);
+			return String.valueOf(getMax(intervalName));
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/VirtualMemoryPoolStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/VirtualMemoryPoolStats.java
@@ -38,7 +38,7 @@ public class VirtualMemoryPoolStats extends AbstractMemoryPoolStats implements I
 	 */
 	public VirtualMemoryPoolStats(String aName,  Interval[] selectedIntervals){
 		super(aName);
-		realStats = new ArrayList<MemoryPoolStats>();
+		realStats = new ArrayList<>();
 	}
 	
 	/**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/producers/AbstractStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/producers/AbstractStats.java
@@ -134,8 +134,6 @@ public abstract class AbstractStats implements IStats, StatsMXBean{
 	protected void addStatValues(StatValue... values){
 		if (values==null)
 			return;
-		for (StatValue v : values){
-			statValuesList.add(v);
-		}
+		Collections.addAll(statValuesList, values);
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/producers/AbstractStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/producers/AbstractStats.java
@@ -60,7 +60,7 @@ public abstract class AbstractStats implements IStats, StatsMXBean{
 	/**
 	 * Cached empty list object.
 	 */
-	private static final List<String> EMPTY_LIST = Collections.unmodifiableList(new ArrayList<String>());
+	private static final List<String> EMPTY_LIST = Collections.emptyList();
 
 	/**
 	 * Contains all stat values that are part of this StatsObject. This is used to properly destroy them.

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/producers/GenericStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/producers/GenericStats.java
@@ -31,7 +31,7 @@ public class GenericStats extends AbstractStats {
      */
     public GenericStats(final String aName) {
         super(aName);
-        this.values = new LinkedHashMap<String, TypeAwareStatValue>();
+        this.values = new LinkedHashMap<>();
     }
 
     /**
@@ -46,7 +46,7 @@ public class GenericStats extends AbstractStats {
      */
     @Override
     public List<String> getAvailableValueNames() {
-        return new ArrayList<String>(values.keySet());
+        return new ArrayList<>(values.keySet());
     }
 
     /**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/IProducerRegistryListener.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/IProducerRegistryListener.java
@@ -34,6 +34,7 @@
  */	
 package net.anotheria.moskito.core.registry;
 
+import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 
 /**
@@ -41,16 +42,16 @@ import net.anotheria.moskito.core.producers.IStatsProducer;
  * @author lrosenberg
  *
  */
-public interface IProducerRegistryListener {
+public interface IProducerRegistryListener<S extends IStats> {
 	/**
 	 * Called whenever a new producer is registered.
 	 * @param producer
 	 */
-	void notifyProducerRegistered(IStatsProducer<?> producer);
+	void notifyProducerRegistered(IStatsProducer<S> producer);
 	
 	/**
 	 * Called whenever a producer is unregistered.
 	 * @param producer
 	 */
-	void notifyProducerUnregistered(IStatsProducer<?> producer);
+	void notifyProducerUnregistered(IStatsProducer<S> producer);
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * This listener registers every new producer as jmx bean.
  */
-public class JMXBridgeListener implements IProducerRegistryListener{
+public class JMXBridgeListener<S extends IStats> implements IProducerRegistryListener<S> {
 
 	/**
 	 * Logger.
@@ -27,10 +27,10 @@ public class JMXBridgeListener implements IProducerRegistryListener{
 	private static Logger log = LoggerFactory.getLogger(JMXBridgeListener.class);
 	
 	@Override
-	public void notifyProducerRegistered(IStatsProducer producer) {
+	public void notifyProducerRegistered(IStatsProducer<S> producer) {
 		if (producer instanceof BuiltInProducer)
 			return;
-		List<IStats> stats = producer.getStats();
+		List<S> stats = producer.getStats();
 		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
 	    if (stats == null)
 	    	return;
@@ -48,8 +48,8 @@ public class JMXBridgeListener implements IProducerRegistryListener{
 	}
 
 	@Override
-	public void notifyProducerUnregistered(IStatsProducer producer) {
-		List<IStats> stats = producer.getStats();
+	public void notifyProducerUnregistered(IStatsProducer<S> producer) {
+		List<S> stats = producer.getStats();
 		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
 	    if (stats == null)
 	    	return;

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
@@ -75,7 +75,7 @@ public class JMXBridgeListener implements IProducerRegistryListener{
 	 */
 	private ObjectName createName(String producerId, String statName) throws MalformedObjectNameException{
 		String appName = encodeAppName(RuntimeConstants.getApplicationName());
-		String objectName = "MoSKito."+(appName.length()>0 ? appName+".":"")+"producers:type="+producerId+"."+statName;
+		String objectName = "MoSKito."+(appName.length()>0 ? appName+ '.' :"")+"producers:type="+producerId+ '.' +statName;
 		ObjectName objName = new ObjectName(objectName);
 		return objName;
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/ProducerRegistryAPIImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/ProducerRegistryAPIImpl.java
@@ -147,9 +147,9 @@ public class ProducerRegistryAPIImpl implements IProducerRegistryAPI, IProducerR
 
 		if (log.isDebugEnabled()){
 			log.debug("Cachedproducer list contains "+_cachedProducerList.size()+" producers: ");
-			log.debug(""+_cachedProducerList);
+			log.debug(String.valueOf(_cachedProducerList));
 			log.debug("Cached producer map contains: "+_cachedProducerMap.size()+" producers");
-			log.debug(""+_cachedProducerMap);
+			log.debug(String.valueOf(_cachedProducerMap));
 		}
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/ProducerRegistryAPIImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/ProducerRegistryAPIImpl.java
@@ -158,7 +158,7 @@ public class ProducerRegistryAPIImpl implements IProducerRegistryAPI, IProducerR
 	@Override public List<IStatsProducer> getAllProducers() {
 		if (_cachedProducerList==null)
 			buildProducerCacheFromScratch();
-		ArrayList<IStatsProducer> ret = new ArrayList<IStatsProducer>();
+		List<IStatsProducer> ret = new ArrayList<>();
 		for (ProducerReference pr : _cachedProducerList){
 			if (pr.get()!=null)
 				ret.add(pr.get());
@@ -228,7 +228,7 @@ public class ProducerRegistryAPIImpl implements IProducerRegistryAPI, IProducerR
 	@Override public List<IStatsProducer> getProducers(IProducerFilter... filters) {
 		if (_cachedProducerList==null)
 			buildProducerCacheFromScratch();
-		List <IStatsProducer> ret = new ArrayList<IStatsProducer>();
+		List <IStatsProducer> ret = new ArrayList<>();
 		@SuppressWarnings("unchecked")
 		List<ProducerReference> workCopy = (List<ProducerReference>)((ArrayList<ProducerReference>)_cachedProducerList).clone();
 		for (ProducerReference p  : workCopy){
@@ -271,7 +271,7 @@ public class ProducerRegistryAPIImpl implements IProducerRegistryAPI, IProducerR
 	}
 
 	@Override public List<String> getCategories() {
-		List<String> ret = new ArrayList<String>();
+		List<String> ret = new ArrayList<>();
 		List<IStatsProducer> producers = getAllProducers();
 		for (IStatsProducer p : producers){
 			if (! (ret.contains(p.getCategory())))
@@ -282,7 +282,7 @@ public class ProducerRegistryAPIImpl implements IProducerRegistryAPI, IProducerR
 	}
 
 	@Override public List<String> getSubsystems() {
-		List<String> ret = new ArrayList<String>();
+		List<String> ret = new ArrayList<>();
 		List<IStatsProducer> producers = getAllProducers();
 		for (IStatsProducer p : producers){
 			if (! (ret.contains(p.getSubsystem())))

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/ProducerRegistryImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/ProducerRegistryImpl.java
@@ -61,7 +61,7 @@ public class ProducerRegistryImpl implements IProducerRegistry {
     /**
      * The map in which the producers are stored.
      */
-    private final ConcurrentMap<String, ProducerReference> registry = new ConcurrentHashMap<String, ProducerReference>();
+    private final ConcurrentMap<String, ProducerReference> registry = new ConcurrentHashMap<>();
 
     /**
      * The listeners list.
@@ -87,7 +87,7 @@ public class ProducerRegistryImpl implements IProducerRegistry {
 
     @Override
     public Collection<IStatsProducer> getProducers() {
-        ArrayList<IStatsProducer> ret = new ArrayList<IStatsProducer>();
+        List<IStatsProducer> ret = new ArrayList<>();
         for (ProducerReference r : getProducerReferences()) {
             if (r.get() != null)
                 ret.add(r.get());

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/ProducerRegistryImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/ProducerRegistryImpl.java
@@ -163,8 +163,7 @@ public class ProducerRegistryImpl implements IProducerRegistry {
      * This method is primary used for unit tests.
      */
     public void cleanup() {
-        ArrayList<ProducerReference> producerReferences = new ArrayList<ProducerReference>();
-        producerReferences.addAll(registry.values());
+        ArrayList<ProducerReference> producerReferences = new ArrayList<ProducerReference>(registry.values());
         for (ProducerReference p : producerReferences) {
             try {
                 if (p.get() != null)

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/snapshot/ProducerSnapshot.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/snapshot/ProducerSnapshot.java
@@ -34,7 +34,7 @@ public class ProducerSnapshot {
 
 	private long timestamp = System.currentTimeMillis();
 
-	private Map<String, StatSnapshot> stats = new HashMap<String, StatSnapshot>();
+	private Map<String, StatSnapshot> stats = new HashMap<>();
 
 	public void setSubsystem(String subsystem) {
 		this.subsystem = subsystem;

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/snapshot/StatSnapshot.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/snapshot/StatSnapshot.java
@@ -18,7 +18,7 @@ public class StatSnapshot {
 	/**
 	 * Map with values.
 	 */
-	private Map<String, String> values = new HashMap<String, String>();
+	private Map<String, String> values = new HashMap<>();
 
 	/**
 	 * Creates a new stat snapshot object.

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/IntValueHolder.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/IntValueHolder.java
@@ -183,11 +183,11 @@ class IntValueHolder extends AbstractValueHolder {
 	}
 	
 	@Override public String getValueAsString() {
-		return ""+lastValue;
+		return String.valueOf(lastValue);
 	}
 
 	@Override public String getCurrentValueAsString() {
-		return ""+currentValue.get();
+		return String.valueOf(currentValue.get());
 	}
 
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/IntervalNameParser.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/IntervalNameParser.java
@@ -100,8 +100,9 @@ class IntervalNameParser {
 	 */
 	private static Map<Character, TimeUnit> lookupMap;
 	static{
-		lookupMap = new HashMap<Character, TimeUnit>();
-		for (TimeUnit u : TimeUnit.values()){
+		TimeUnit[] timeUnits = TimeUnit.values();
+		lookupMap = new HashMap<>(timeUnits.length);
+		for (TimeUnit u : timeUnits){
 			lookupMap.put(u.getCaption(), u);
 		}
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/IntervalRegistry.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/IntervalRegistry.java
@@ -63,17 +63,17 @@ public final class IntervalRegistry {
 	/**
 	 * This Map holds all Intervals by their ids.
 	 */
-	private Map<Integer, Interval> intervalsById = new ConcurrentHashMap<Integer, Interval>();
+	private Map<Integer, Interval> intervalsById = new ConcurrentHashMap<>();
 
 	/**
 	 * This Map holds all Intervals by their names.
 	 */
-	private Map<String, Interval> intervalsByName = new ConcurrentHashMap<String, Interval>();
+	private Map<String, Interval> intervalsByName = new ConcurrentHashMap<>();
 	
 	/**
 	 * This map stores last update timestamps for registered intervals by name.
 	 */
-	private Map<String, Long> intervalUpdateTimestamp = new ConcurrentHashMap<String, Long>();
+	private Map<String, Long> intervalUpdateTimestamp = new ConcurrentHashMap<>();
 
 	/**
 	 * This is a Thread-safe counter to generate VM-wide uniqe ids for new Interval instances.

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/LongValueHolder.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/LongValueHolder.java
@@ -202,11 +202,11 @@ class LongValueHolder extends AbstractValueHolder {
 	}
 
 	@Override public String getValueAsString() {
-		return ""+lastValue;
+		return String.valueOf(lastValue);
 	}
 
 	@Override public String getCurrentValueAsString() {
-		return ""+currentValue.get();
+		return String.valueOf(currentValue.get());
 	}
 
 	protected void setLastValue(long aValue){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/StatValueImpl.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/StatValueImpl.java
@@ -97,8 +97,8 @@ class StatValueImpl implements StatValue {
 	public StatValueImpl(String aName, IValueHolderFactory aFactory){
 		name = aName;
 		factory = aFactory;
-		values = new HashMap<String, ValueHolder>();
-		valuesAsList = new ArrayList<ValueHolder>();
+		values = new HashMap<>();
+		valuesAsList = new ArrayList<>();
 		// now we have to add the ValueHolder for the absolute value
 		absoluteValue = factory.createValueHolder(ABSOLUTE_VALUE);
 		values.put(ABSOLUTE_VALUE.getName(), absoluteValue);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/StringValueHolder.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/stats/impl/StringValueHolder.java
@@ -140,7 +140,7 @@ class StringValueHolder extends AbstractValueHolder {
 	}
 
 	@Override public void setValueAsInt(int aValue) {
-		currentValue = ""+aValue;
+		currentValue = String.valueOf(aValue);
 	}
 
 	@Override public void setValueAsLong(long aValue) {
@@ -152,7 +152,7 @@ class StringValueHolder extends AbstractValueHolder {
 	}
 
 	@Override public void setDefaultValueAsInt(int aValue) {
-		defaultValue = ""+aValue;
+		defaultValue = String.valueOf(aValue);
 	}
 
 	@Override public void setDefaultValueAsDouble(double aValue) {
@@ -184,7 +184,7 @@ class StringValueHolder extends AbstractValueHolder {
 		return lastValue;
 	}
 	@Override public String getCurrentValueAsString() {
-		return ""+currentValue;
+		return currentValue;
 	}
 
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/Threshold.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/Threshold.java
@@ -59,7 +59,7 @@ public class Threshold extends AbstractTieable<ThresholdDefinition> implements T
 		super(aDefinition);
 		status = ThresholdStatus.OFF;
 		lastValue = "none yet";
-		guards = new ArrayList<ThresholdConditionGuard>();
+		guards = new ArrayList<>();
 		flipCount = 0;
 	}
 	

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/Threshold.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/Threshold.java
@@ -145,7 +145,7 @@ public class Threshold extends AbstractTieable<ThresholdDefinition> implements T
 	}
 	
 	@Override public String toString(){
-		return getName()+" "+getStatus()+" Def: "+getDefinition()+" LastValue: "+getLastValue()+", Guards: "+guards+" active: "+isActivated()+", Stats: "+getStats();
+		return getName()+ ' ' +getStatus()+" Def: "+getDefinition()+" LastValue: "+getLastValue()+", Guards: "+guards+" active: "+isActivated()+", Stats: "+getStats();
 	}
 
 	public long getStatusChangeTimestamp() {

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/ThresholdRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/ThresholdRepository.java
@@ -108,7 +108,7 @@ public class ThresholdRepository extends TieableRepository<Threshold> {
 	
 	private ObjectName createName(String name) throws MalformedObjectNameException {
         String appName = RuntimeConstants.getApplicationName();
-		String objectName = "moskito."+(appName.length()>0 ? appName+".":"")+"thresholds:type="+name;
+		String objectName = "moskito."+(appName.length()>0 ? appName+ '.' :"")+"thresholds:type="+name;
         ObjectName objName = new ObjectName(objectName);
         return objName;
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/ThresholdRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/ThresholdRepository.java
@@ -33,7 +33,7 @@ import java.util.List;
 /**
  * Repository that contains currently configured thresholds.
  */
-public class ThresholdRepository extends TieableRepository<Threshold> {
+public class ThresholdRepository<S extends IStats> extends TieableRepository<Threshold, S> {
 
 	/**
 	 * Logger.
@@ -43,7 +43,7 @@ public class ThresholdRepository extends TieableRepository<Threshold> {
 	/**
 	 * Singleton instance of this class.
 	 */
-	private static ThresholdRepository INSTANCE = new ThresholdRepository();
+	private static ThresholdRepository<? extends IStats> INSTANCE = new ThresholdRepository<>();
 
 
 	/**
@@ -57,7 +57,7 @@ public class ThresholdRepository extends TieableRepository<Threshold> {
 	 * Returns the singleton instance of the registry.
 	 * @return
 	 */
-	public static ThresholdRepository getInstance(){
+	public static ThresholdRepository<? extends IStats> getInstance(){
 		return INSTANCE;
 	}
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/alerts/AlertHistory.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/alerts/AlertHistory.java
@@ -56,8 +56,7 @@ public enum AlertHistory {
 	 * @return
 	 */
 	public List<ThresholdAlert> getAlerts(){
-		List<ThresholdAlert> ret = new ArrayList<ThresholdAlert>();
-		ret.addAll(alerts);
+		List<ThresholdAlert> ret = new ArrayList<ThresholdAlert>(alerts);
 		Collections.reverse(ret);
 		return ret;
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/alerts/ThresholdAlert.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/alerts/ThresholdAlert.java
@@ -95,9 +95,9 @@ public class ThresholdAlert {
 	}
 
 	@Override public String toString(){
-		return NumberUtils.makeISO8601TimestampString(getTimestamp())+" "
+		return NumberUtils.makeISO8601TimestampString(getTimestamp())+ ' '
 				+threshold.getName()+", ("+getOldStatus()+"/ "+getOldValue()+") --> "+
-				"("+getNewStatus()+"/ "+getNewValue()+")"+" FP: "+flipCount;
+				'(' +getNewStatus()+"/ "+getNewValue()+ ')' +" FP: "+flipCount;
 	}
 	
 	

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/alerts/notificationprovider/LogFileNotificationProvider.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/alerts/notificationprovider/LogFileNotificationProvider.java
@@ -28,6 +28,6 @@ public class LogFileNotificationProvider implements NotificationProvider{
 			LoggerFactory.getLogger(LogFileNotificationProvider.class).warn("Logger not set, cannot log, aborted.");
 			return;
 		}
-		log.info(""+alert);
+		log.info(String.valueOf(alert));
 	}
 }

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/guard/BarrierPassGuard.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/guard/BarrierPassGuard.java
@@ -37,7 +37,7 @@ public abstract class BarrierPassGuard implements ThresholdConditionGuard, Seria
 	}
 	
 	@Override public String toString(){
-		return targetStatus+" if "+direction+" "+getValueAsString();
+		return targetStatus+" if "+direction+ ' ' +getValueAsString();
 	}
 	/**
 	 * Returns the value as string for alert generation.

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/guard/DoubleBarrierPassGuard.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/guard/DoubleBarrierPassGuard.java
@@ -19,7 +19,7 @@ public class DoubleBarrierPassGuard extends BarrierPassGuard{
 	
 	@Override
 	public String getValueAsString(){
-		return ""+barrierValue;
+		return String.valueOf(barrierValue);
 	}
 	@Override
 	protected Number getValueAsNumber(String aValue){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/guard/LongBarrierPassGuard.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/guard/LongBarrierPassGuard.java
@@ -30,7 +30,7 @@ public class LongBarrierPassGuard extends BarrierPassGuard implements Serializab
 	}
 	
 	@Override public String getValueAsString(){
-		return ""+barrierValue;
+		return String.valueOf(barrierValue);
 	}
 	
 	@Override protected Number getValueAsNumber(String aValue){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/tracer/Trace.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/tracer/Trace.java
@@ -55,7 +55,7 @@ public class Trace implements IComparable<Trace>{
 	}
 
 	@Override public String toString(){
-		return id+" "+call+" "+(elements==null? "no elements" : Arrays.toString(getElements()))+", dur: "+duration;
+		return id+" "+call+ ' ' +(elements==null? "no elements" : Arrays.toString(getElements()))+", dur: "+duration;
 	}
 
 	public long getId(){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/tracer/TracerRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/tracer/TracerRepository.java
@@ -85,7 +85,7 @@ public class TracerRepository {
 		if (config.isLoggingEnabled()){
 			traceLog.info(NumberUtils.makeISO8601TimestampString()+", call: "+aNewTrace.getCall()+" duration: "+aNewTrace.getDuration());
 			for (StackTraceElement e : aNewTrace.getElements()){
-				traceLog.info("\t"+e.toString());
+				traceLog.info('\t' +e.toString());
 			}
 		}
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/tracer/TracerRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/tracer/TracerRepository.java
@@ -36,7 +36,7 @@ public class TracerRepository {
 	/**
 	 * Currently existing tracers.
 	 */
-	private ConcurrentMap<String,Tracer> tracers = new ConcurrentHashMap<String, Tracer>();
+	private ConcurrentMap<String,Tracer> tracers = new ConcurrentHashMap<>();
 
 	/**
 	 * Private constructor.

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/BuiltInMemoryPoolProducer.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/BuiltInMemoryPoolProducer.java
@@ -40,7 +40,7 @@ public class BuiltInMemoryPoolProducer  extends AbstractBuiltInProducer  impleme
 	 */
 	public BuiltInMemoryPoolProducer(MemoryPoolMXBean aPool){
 		pool = aPool;
-		producerId = "MemoryPool-"+pool.getName()+"-"+(pool.getType()==MemoryType.HEAP? "Heap" : "NonHeap");
+		producerId = "MemoryPool-"+pool.getName()+ '-' +(pool.getType()==MemoryType.HEAP? "Heap" : "NonHeap");
 		statsList = new CopyOnWriteArrayList<IStats>();
 		stats = new MemoryPoolStats(producerId);
 		statsList.add(stats);
@@ -90,7 +90,7 @@ public class BuiltInMemoryPoolProducer  extends AbstractBuiltInProducer  impleme
 	}
 	
 	@Override public String toString(){
-		return super.toString()+" "+pool.getName();
+		return super.toString()+ ' ' +pool.getName();
 	}
 }
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/BuiltInMemoryProducer.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/BuiltInMemoryProducer.java
@@ -129,7 +129,7 @@ public class BuiltInMemoryProducer  extends AbstractBuiltInProducer implements I
 	}
 	
 	@Override public String toString(){
-		return super.toString()+" "+resolver.getClass().getSimpleName();
+		return super.toString()+ ' ' +resolver.getClass().getSimpleName();
 	}
 }
 

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/BuiltInThreadStatesProducer.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/BuiltInThreadStatesProducer.java
@@ -8,10 +8,7 @@ import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -44,7 +41,7 @@ public class BuiltInThreadStatesProducer extends AbstractBuiltInProducer<ThreadS
 
 		cumulated = new ThreadStateStats("cumulated");
 
-		statsMap = new HashMap<Thread.State, ThreadStateStats>();
+		statsMap = new EnumMap<>(Thread.State.class);
 		statsList = new CopyOnWriteArrayList<ThreadStateStats>();
 		statsList.add(cumulated);
 		for (Thread.State state : Thread.State.values()){
@@ -72,7 +69,7 @@ public class BuiltInThreadStatesProducer extends AbstractBuiltInProducer<ThreadS
 	private void readThreads(){
 		long[] ids = threadMxBean.getAllThreadIds();
 
-		HashMap<Thread.State, Long> count = new HashMap<Thread.State, Long>();
+		Map<Thread.State, Long> count = new EnumMap<>(Thread.State.class);
 		for (int i = 0; i<ids.length; i++){
 			long id = ids[i];
 			ThreadInfo info = threadMxBean.getThreadInfo(id);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/MBeanProducerFactory.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/MBeanProducerFactory.java
@@ -40,7 +40,7 @@ public final class MBeanProducerFactory {
 	 */
     public static Iterable<SimpleStatsProducer<GenericStats>> buildProducers() {
 
-        final Collection<SimpleStatsProducer<GenericStats>> result = new ArrayList<SimpleStatsProducer<GenericStats>>();
+        final Collection<SimpleStatsProducer<GenericStats>> result = new ArrayList<>();
 
         for (final MBeanServer server : getServers()) {
             if (LOGGER.isDebugEnabled()) {

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/StartBuiltInProducers.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/StartBuiltInProducers.java
@@ -64,7 +64,7 @@ public class StartBuiltInProducers {
 				registry.registerProducer(p);
 				List<BuiltInMemoryPoolProducer> pp = producers.get(pool.getType());
 				if (pp==null){
-					pp = new ArrayList<BuiltInMemoryPoolProducer>();
+					pp = new ArrayList<>(pools.size());
 					producers.put(pool.getType(), pp);
 				}
 				pp.add(p);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/StartBuiltInProducers.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/StartBuiltInProducers.java
@@ -7,10 +7,7 @@ import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * A utility for starting built-in producers upon moskito start / initialization.
@@ -59,7 +56,7 @@ public class StartBuiltInProducers {
 		}
 
 		if (MoskitoConfigurationHolder.getConfiguration().getBuiltinProducersConfig().isJavaMemoryPoolProducers()){
-			HashMap<MemoryType, List<BuiltInMemoryPoolProducer>> producers = new HashMap<MemoryType, List<BuiltInMemoryPoolProducer>>();
+			Map<MemoryType, List<BuiltInMemoryPoolProducer>> producers = new EnumMap<>(MemoryType.class);
 
 			List<MemoryPoolMXBean> pools = ManagementFactory.getMemoryPoolMXBeans();
 			for (MemoryPoolMXBean pool : pools){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/session/SessionCountStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/session/SessionCountStats.java
@@ -122,15 +122,15 @@ public class SessionCountStats extends AbstractStats {
 		valueName = valueName.toLowerCase();
 		
 		if (valueName.equals("cur") || valueName.equals("current"))
-			return ""+getCurrentSessionCount(intervalName);
+			return String.valueOf(getCurrentSessionCount(intervalName));
 		if (valueName.equals("min"))
-			return ""+getMinSessionCount(intervalName);
+			return String.valueOf(getMinSessionCount(intervalName));
 		if (valueName.equals("max"))
-			return ""+getMaxSessionCount(intervalName);
+			return String.valueOf(getMaxSessionCount(intervalName));
 		if (valueName.equals("new"))
-			return ""+getCreatedSessionCount(intervalName);
+			return String.valueOf(getCreatedSessionCount(intervalName));
 		if (valueName.equals("del"))
-			return ""+getDestroyedSessionCount(intervalName);
+			return String.valueOf(getDestroyedSessionCount(intervalName));
 		
 		return super.getValueByNameAsString(valueName, intervalName, timeUnit);
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/storage/Storage.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/storage/Storage.java
@@ -79,7 +79,7 @@ public class Storage<K,V> implements IStatsProducer<StorageStats>, Inspectable, 
 	 * @param aWrapper wrapper name
 	 */
 	public Storage(String aName, StorageWrapper<K, V> aWrapper){
-		name = aName + "-"+ instanceCount.incrementAndGet();
+		name = aName + '-' + instanceCount.incrementAndGet();
 		wrapper = aWrapper;
 		stats = new StorageStats(name);
 		

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/storage/Storage.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/storage/Storage.java
@@ -363,7 +363,7 @@ public class Storage<K,V> implements IStatsProducer<StorageStats>, Inspectable, 
 	 * @return
 	 */
 	public static <K,V> Storage<K,V> createHashtableStorage(){
-		return new Storage<K,V>(new MapStorageWrapper<K, V>(new Hashtable<K, V>()));
+		return new Storage<K,V>(new MapStorageWrapper<K, V>(new HashMap<K, V>()));
 	}
 
 	/**
@@ -374,7 +374,7 @@ public class Storage<K,V> implements IStatsProducer<StorageStats>, Inspectable, 
 	 * @return
 	 */
 	public static <K,V> Storage<K,V> createHashtableStorage(int initialSize){
-		return new Storage<K,V>(new MapStorageWrapper<K, V>(new Hashtable<K, V>(initialSize)));
+		return new Storage<K,V>(new MapStorageWrapper<K, V>(new HashMap<K, V>(initialSize)));
 	}
 
 	/**
@@ -385,7 +385,7 @@ public class Storage<K,V> implements IStatsProducer<StorageStats>, Inspectable, 
 	 * @return
 	 */
 	public static <K,V> Storage<K,V> createHashtableStorage(String name){
-		return new Storage<K,V>(name, new MapStorageWrapper<K, V>(new Hashtable<K, V>()));
+		return new Storage<K,V>(name, new MapStorageWrapper<K, V>(new HashMap<K, V>()));
 	}
 
 	/**
@@ -397,7 +397,7 @@ public class Storage<K,V> implements IStatsProducer<StorageStats>, Inspectable, 
 	 * @return
 	 */
 	public static <K,V> Storage<K,V> createHashtableStorage(String name, int initialSize){
-		return new Storage<K,V>(name, new MapStorageWrapper<K, V>(new Hashtable<K, V>(initialSize)));
+		return new Storage<K,V>(name, new MapStorageWrapper<K, V>(new HashMap<K, V>(initialSize)));
 	}
 
 	/**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryEvent.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryEvent.java
@@ -56,7 +56,7 @@ public class ThreadHistoryEvent implements Serializable{
 	}
 	
 	@Override public String toString(){
-		return getNiceTimestamp()+" "+getThreadId()+" "+getThreadName()+" "+getOperation();
+		return getNiceTimestamp()+ ' ' +getThreadId()+ ' ' +getThreadName()+ ' ' +getOperation();
 	}
 
 	public long getThreadId() {

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtility.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtility.java
@@ -89,7 +89,7 @@ public enum ThreadHistoryUtility {
 		lock.writeLock().lock();
 		try{
 			long[] ids = mxBean.getAllThreadIds();
-			HashSet<Long> oldIds = (HashSet<Long> )runningThreadIds.clone();
+			Set<Long> oldIds = new HashSet<>(runningThreadIds);
 			for (long _id : ids){
 				Long id = _id;
 				oldIds.remove(id);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtility.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtility.java
@@ -2,11 +2,7 @@ package net.anotheria.moskito.core.util.threadhistory;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -36,7 +32,7 @@ public enum ThreadHistoryUtility {
 	/**
 	 * Ids of all currently running threads.
 	 */
-	private HashSet<Long> runningThreadIds = new HashSet<Long>();
+	private Set<Long> runningThreadIds = new HashSet<>();
 	
 	/**
 	 * ThreadMXBean reference.
@@ -50,7 +46,7 @@ public enum ThreadHistoryUtility {
 	/**
 	 * The storage for history events.
 	 */
-	private ArrayList<ThreadHistoryEvent> eventList = new ArrayList<ThreadHistoryEvent>();
+	private List<ThreadHistoryEvent> eventList = new ArrayList<>();
 	
 	/**
 	 * Internal synchronization lock.

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtility.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtility.java
@@ -104,7 +104,7 @@ public enum ThreadHistoryUtility {
 				}
 			}
 			//now check deleted
-			for (Long oldId : oldIds.toArray(PATTERN)){
+			for (Long oldId : oldIds.toArray(new Long[oldIds.size()])){
 				ThreadHistoryEvent event = ThreadHistoryEvent.deleted(oldId, "");
 				runningThreadIds.remove(oldId);
 				eventList.add(event);

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtility.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtility.java
@@ -124,9 +124,9 @@ public enum ThreadHistoryUtility {
 	public List<ThreadHistoryEvent> getThreadHistoryEvents(){
 		ArrayList<ThreadHistoryEvent> ret = null;
 		lock.readLock().lock();
-		try{
-			ret = (ArrayList<ThreadHistoryEvent>) eventList.clone();
-		}finally{
+		try {
+			ret = new ArrayList<>(eventList);
+		} finally {
 			lock.readLock().unlock();
 		}
 		return ret;

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/accumulation/AccumulatorTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/accumulation/AccumulatorTest.java
@@ -15,7 +15,7 @@ public class AccumulatorTest {
 		def.setAccumulationAmount(limit);
 		
 		for (int i=0; i<limit; i++){
-			acc.addValue(""+i);
+			acc.addValue(String.valueOf(i));
 			assertEquals(i+1, acc.getValues().size());
 		}
 		

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/accumulation/MSK156Test.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/accumulation/MSK156Test.java
@@ -16,7 +16,7 @@ public class MSK156Test {
 
 		//fill the list.
 		for (int i=0; i<10; i++){
-			acc.addValue("" + i);
+			acc.addValue(String.valueOf(i));
 		}
 
 		//this call shouldn't crash yet.
@@ -24,7 +24,7 @@ public class MSK156Test {
 
 		//fill the list until the sublist is too long, 2800 or more.
 		for (int i=0; i<5600*2; i++){
-			acc.addValue("" + i);
+			acc.addValue(String.valueOf(i));
 		}
 
 		//this call should produce stackoverflow.

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/config/dashboards/ChartConfigTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/config/dashboards/ChartConfigTest.java
@@ -1,0 +1,25 @@
+package net.anotheria.moskito.core.config.dashboards;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.*;
+
+public class ChartConfigTest {
+
+    @Test(expected = NullPointerException.class)
+    public void buildCaptionAccumulatorsEmpty() throws Exception {
+        ChartConfig chartConfig = new ChartConfig();
+        String caption = chartConfig.buildCaption();
+    }
+
+    @Test
+    public void buildCaptionAccumulatorsNonEmpty() throws Exception {
+        ChartConfig chartConfig = new ChartConfig();
+        chartConfig.setAccumulators(new String[] {"fair", "is", "foul", "and", "foul", "is", "fair"});
+        String caption = chartConfig.buildCaption();
+        assertThat(caption, is("fair is foul and foul is fair"));
+    }
+
+}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/DecoratorRegistryTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/DecoratorRegistryTest.java
@@ -19,8 +19,8 @@ import net.anotheria.moskito.core.util.storage.StorageStats;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class DecoratorRegistryTest {
 	

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/value/DoubleValueAOTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/value/DoubleValueAOTest.java
@@ -1,0 +1,153 @@
+package net.anotheria.moskito.core.decorators.value;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+
+public class DoubleValueAOTest {
+
+
+    @Test
+    public void nANIsFormattedCorrectly() {
+        assertFormatting(Double.NaN, "0.000");
+    }
+
+    @Test
+    public void negativeInfinityIsFormattedCorrectly() {
+        assertFormatting(Double.NEGATIVE_INFINITY, "-\u221e");
+    }
+
+    @Test
+    public void positiveInfinityIsFormattedCorrectly() {
+        assertFormatting(Double.POSITIVE_INFINITY, "\u221e");
+    }
+
+    @Test
+    public void zeroIsFormattedCorrectly1() {
+        assertFormatting(0.0, "0.000");
+    }
+
+    @Test
+    public void zeroIsFormattedCorrectly2() {
+        assertFormatting(-0.0, "0.000");
+    }
+
+    @Test
+    public void wholeNumberIsFormattedCorrectly() {
+        assertFormatting(42.0, "42.000");
+    }
+
+    @Test
+    public void smallPositiveDoubleIsFormattedCorrectly() {
+        assertFormatting(.123456789, "0.123");
+    }
+
+    @Test
+    public void smallNegativeDoubleIsFormattedCorrectly() {
+        assertFormatting(-.123456789, "-0.123");
+    }
+
+    @Test
+    public void veryShortPositiveDoubleIsFormattedCorrectly7() {
+        assertFormatting(Double.MIN_VALUE, "0.000");
+    }
+
+    @Test
+    public void shortPositiveDoubleIsFormattedCorrectly1() {
+        assertFormatting(1.0, "1.000");
+    }
+
+    @Test
+    public void shortPositiveDoubleIsFormattedCorrectly2() {
+        assertFormatting(47.11, "47.110");
+    }
+
+    @Test
+    public void longPositiveDoubleIsFormattedCorrectly1() {
+        assertFormatting(1.23456789, "1.235");
+    }
+
+    @Test
+    public void longPositiveDoubleIsFormattedCorrectly2() {
+        assertFormatting(12.3456789, "12.346");
+    }
+
+    @Test
+    public void longPositiveDoubleIsFormattedCorrectly3() {
+        assertFormatting(123.456789, "123.457");
+    }
+
+    @Test
+    public void longPositiveDoubleIsFormattedCorrectly4() {
+        assertFormatting(12345.6789, "12345.679");
+    }
+
+    @Test
+    public void longPositiveDoubleIsFormattedCorrectly5() {
+        assertFormatting(123456.789, "123456.789");
+    }
+
+    @Test
+    public void longPositiveDoubleIsFormattedCorrectly6() {
+        assertFormatting(1234567.89, "1234567.890");
+    }
+
+    @Test
+    public void longPositiveDoubleIsFormattedCorrectly7() {
+        assertFormatting(12345678.9, "12345678.900");
+    }
+
+    @Test
+    public void longNegativeDoubleIsFormattedCorrectly1() {
+        assertFormatting(-1.23456789, "-1.235");
+    }
+
+    @Test
+    public void longNegativeDoubleIsFormattedCorrectly2() {
+        assertFormatting(-12.3456789, "-12.346");
+    }
+
+    @Test
+    public void longNegativeDoubleIsFormattedCorrectly3() {
+        assertFormatting(-123.456789, "-123.457");
+    }
+
+    @Test
+    public void longNegativeDoubleIsFormattedCorrectly4() {
+        assertFormatting(-12345.6789, "-12345.679");
+    }
+
+    @Test
+    public void longNegativeDoubleIsFormattedCorrectly5() {
+        assertFormatting(-123456.789, "-123456.789");
+    }
+
+    @Test
+    public void longNegativeDoubleIsFormattedCorrectly6() {
+        assertFormatting(-1234567.89, "-1234567.890");
+    }
+
+    @Test
+    public void longNegativeDoubleIsFormattedCorrectly7() {
+        assertFormatting(-12345678.9, "-12345678.900");
+    }
+
+    @Test
+    public void veryLongPositiveDoubleIsFormattedCorrectly7() {
+        assertFormatting(Double.MAX_VALUE, "9223372036854776.000");
+    }
+
+    @Test
+    public void piIsFormattedCorrectly() {
+        assertFormatting(Math.PI, "3.142");
+    }
+
+    public void assertFormatting(double doubleValue, String expected) {
+        DoubleValueAO doubleValueAO = new DoubleValueAO("name", doubleValue);
+        String returnValue = doubleValueAO.getValue();
+        assertThat(returnValue, is(expected));
+    }
+
+}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/EntryCountLimitedOnDemandStatsProducerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/EntryCountLimitedOnDemandStatsProducerTest.java
@@ -22,7 +22,7 @@ public class EntryCountLimitedOnDemandStatsProducerTest {
 		p.setLimit(limit);
 		assertEquals("expected previously set limit", limit, p.getLimit());
 		for (int i=0; i<limit; i++)
-			p.getStats(""+i);
+			p.getStats(String.valueOf(i));
 		//now limit should be reached.
 		try{
 			p.getStats("bla");

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducerTest.java
@@ -114,7 +114,7 @@ public class OnDemandStatsProducerTest {
 			for (int i=0; i<REQUEST_COUNT; i++){
 				int r = rnd.nextInt(RANDOM_COUNT);
 				try{
-					ServiceStats stats = producer.getStats(""+r);
+					ServiceStats stats = producer.getStats(String.valueOf(r));
 					stats.addRequest();
 				}catch(OnDemandStatsProducerException ignored){
 					ignored.printStackTrace();

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/ProxyUtilsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/ProxyUtilsTest.java
@@ -1,0 +1,44 @@
+package net.anotheria.moskito.core.dynamic;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.Assert.*;
+
+/**
+ * Created by dheid on 28.05.16.
+ */
+public class ProxyUtilsTest {
+
+    private interface TestInterfaceA {
+
+    }
+
+    private interface TestInterfaceB {
+
+    }
+
+    private interface TestInterfaceC {
+
+    }
+
+    @Test
+    public void createInstance() throws Exception {
+        Class interf = TestInterfaceA.class;
+        Class[] additionalClasses = new Class<?>[] {
+                TestInterfaceB.class,
+                TestInterfaceC.class
+        };
+        Class[] mergedInterfaces = ProxyUtils.mergeInterfaces(interf, additionalClasses);
+
+        assertThat(mergedInterfaces, arrayWithSize(3));
+        assertThat(mergedInterfaces[0] == TestInterfaceA.class, is(true));
+        assertThat(mergedInterfaces[1] == TestInterfaceB.class, is(true));
+        assertThat(mergedInterfaces[2] == TestInterfaceC.class, is(true));
+    }
+
+}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/RequestOrientedStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/RequestOrientedStatsTest.java
@@ -79,16 +79,16 @@ public class RequestOrientedStatsTest {
 		stats.addExecutionTime(150000); //100 ms
 		stats.addRequest();
 		IntervalRegistry.getInstance().forceUpdateIntervalForTestingPurposes("1m");
-		assertEquals(""+stats.getAverageRequestDuration("1m", TimeUnit.MICROSECONDS), stats.getValueByNameAsString("avg", "1m", TimeUnit.MICROSECONDS));
-		assertEquals(""+stats.getAverageRequestDuration("1m", TimeUnit.MILLISECONDS), stats.getValueByNameAsString("avg", "1m", TimeUnit.MILLISECONDS));
+		assertEquals(String.valueOf(stats.getAverageRequestDuration("1m", TimeUnit.MICROSECONDS)), stats.getValueByNameAsString("avg", "1m", TimeUnit.MICROSECONDS));
+		assertEquals(String.valueOf(stats.getAverageRequestDuration("1m", TimeUnit.MILLISECONDS)), stats.getValueByNameAsString("avg", "1m", TimeUnit.MILLISECONDS));
 		assertEquals("125.0",  stats.getValueByNameAsString("avg", "1m", TimeUnit.MICROSECONDS));
 
 		stats.addExecutionTime(77777777);
 		stats.addRequest();
 		IntervalRegistry.getInstance().forceUpdateIntervalForTestingPurposes("1m");
-		assertEquals(""+stats.getAverageRequestDuration("1m", TimeUnit.MICROSECONDS), stats.getValueByNameAsString("avg", "1m", TimeUnit.MICROSECONDS));
-		assertEquals(""+stats.getAverageRequestDuration("1m", TimeUnit.MILLISECONDS), stats.getValueByNameAsString("avg", "1m", TimeUnit.MILLISECONDS));
-		assertEquals(""+stats.getAverageRequestDuration("1m", TimeUnit.SECONDS), stats.getValueByNameAsString("avg", "1m", TimeUnit.SECONDS));
+		assertEquals(String.valueOf(stats.getAverageRequestDuration("1m", TimeUnit.MICROSECONDS)), stats.getValueByNameAsString("avg", "1m", TimeUnit.MICROSECONDS));
+		assertEquals(String.valueOf(stats.getAverageRequestDuration("1m", TimeUnit.MILLISECONDS)), stats.getValueByNameAsString("avg", "1m", TimeUnit.MILLISECONDS));
+		assertEquals(String.valueOf(stats.getAverageRequestDuration("1m", TimeUnit.SECONDS)), stats.getValueByNameAsString("avg", "1m", TimeUnit.SECONDS));
 		assertEquals("77777.0",  stats.getValueByNameAsString("avg", "1m", TimeUnit.MICROSECONDS));
 		assertEquals("77.0",  stats.getValueByNameAsString("avg", "1m", TimeUnit.MILLISECONDS));
 		assertEquals("0.0",  stats.getValueByNameAsString("avg", "1m", TimeUnit.SECONDS));

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/ThresholdConfigTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/ThresholdConfigTest.java
@@ -81,8 +81,8 @@ public class ThresholdConfigTest {
 	}
 
 	@Test public void findConfiguredThreshold(){
-		Threshold first = ThresholdRepository.getInstance().getByName("ThresholdConfigTest-FIRST");
-		Threshold second = ThresholdRepository.getInstance().getByName("ThresholdConfigTest-SECOND");
+		Threshold first =  ThresholdRepository.getInstance().getByName("ThresholdConfigTest-FIRST");
+		Threshold second =  ThresholdRepository.getInstance().getByName("ThresholdConfigTest-SECOND");
 		assertNotNull(first);
 		assertNotNull(second);
 		assertNull(first.getStats());

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/tracer/ShrinkingStrategyTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/tracer/ShrinkingStrategyTest.java
@@ -57,7 +57,7 @@ public class ShrinkingStrategyTest {
 		//now fill first 22 traces
 		for (int i=0; i<22; i++){
 			Trace t = new Trace();
-			t.setCall(""+i);
+			t.setCall(String.valueOf(i));
 			t.setDuration(rnd.nextInt(500));
 			tracer.addTrace(t, 22, 20);
 		}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/tracer/TracerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/tracer/TracerTest.java
@@ -42,7 +42,7 @@ public class TracerTest {
 		//now fill first 20 traces
 		for (int i=0; i<max; i++){
 			Trace t = new Trace();
-			t.setCall(""+i);
+			t.setCall(String.valueOf(i));
 			tracer.addTrace(t, tolerated, max);
 		}
 
@@ -50,7 +50,7 @@ public class TracerTest {
 
 		for (int i=max; i<tolerated; i++){
 			Trace t = new Trace();
-			t.setCall(""+i);
+			t.setCall(String.valueOf(i));
 			tracer.addTrace(t, tolerated, max);
 		}
 
@@ -65,7 +65,7 @@ public class TracerTest {
 
 
 		assertEquals(max, tracer.getEntryCount());
-		assertEquals("" + (tolerated - max +1), tracer.getTraces().get(0).getCall());
+		assertEquals(String.valueOf(tolerated - max + 1), tracer.getTraces().get(0).getCall());
 		assertEquals("Ensure we have same last element, ", overflow.getCall(), tracer.getTraces().get(tracer.getTraces().size() - 1).getCall());
 
 

--- a/moskito-extensions/moskito-additional-producers/src/main/java/net/anotheria/moskito/extensions/producers/RollingOnDemandStatsProducer.java
+++ b/moskito-extensions/moskito-additional-producers/src/main/java/net/anotheria/moskito/extensions/producers/RollingOnDemandStatsProducer.java
@@ -188,7 +188,7 @@ public class RollingOnDemandStatsProducer<S extends IStats> implements IStatsPro
 	}
 	
 	@Override public String toString(){
-		return "RollingOnDemandStatsProducer: "+getProducerId()+":"+getSubsystem()+":"+getCategory();
+		return "RollingOnDemandStatsProducer: "+getProducerId()+ ':' +getSubsystem()+ ':' +getCategory();
 	}
 	
 	protected List<S> getCachedStatsList(){

--- a/moskito-extensions/moskito-disk-space-monitoring/pom.xml
+++ b/moskito-extensions/moskito-disk-space-monitoring/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
           <groupId>com.sun.jersey</groupId>
           <artifactId>jersey-client</artifactId>
-          <version>1.18</version>
+          <version>${jersey-version}</version>
       </dependency>
       <dependency>
 		<groupId>net.anotheria</groupId>

--- a/moskito-extensions/moskito-disk-space-monitoring/src/main/java/net/anotheria/moskito/extensions/diskspacemonitoring/DiscSpaceProducer.java
+++ b/moskito-extensions/moskito-disk-space-monitoring/src/main/java/net/anotheria/moskito/extensions/diskspacemonitoring/DiscSpaceProducer.java
@@ -101,6 +101,6 @@ public class DiscSpaceProducer implements IStatsProducer {
     }
 
     @Override public String toString(){
-        return super.toString()+" "+this.getClass().getSimpleName();
+        return super.toString()+ ' ' +this.getClass().getSimpleName();
     }
 }

--- a/moskito-extensions/moskito-mongodb/src/main/java/net/anotheria/moskito/extension/mongodb/MongodbMonitor.java
+++ b/moskito-extensions/moskito-mongodb/src/main/java/net/anotheria/moskito/extension/mongodb/MongodbMonitor.java
@@ -59,10 +59,11 @@ public class MongodbMonitor {
     }
 
     private List<MongoCredential> createMongoCredentials(MongodbMonitorConfig config) {
-        List<MongoCredential> mongoCredentials = new ArrayList<>();
         if (config.getLogin() == null) {
-            return mongoCredentials;
+            return new ArrayList<>(0);
         }
+
+        List<MongoCredential> mongoCredentials = new ArrayList<>(1);
         mongoCredentials.add(MongoCredential.createCredential(config.getLogin(), config.getDbName(), config.getPassword().toCharArray()));
         return mongoCredentials;
     }

--- a/moskito-extensions/moskito-mongodb/src/main/java/net/anotheria/moskito/extension/mongodb/MongodbStats.java
+++ b/moskito-extensions/moskito-mongodb/src/main/java/net/anotheria/moskito/extension/mongodb/MongodbStats.java
@@ -117,13 +117,13 @@ public class MongodbStats extends AbstractStats {
             return getFlushes().getValueAsString(intervalName);
         }
         if (valueName.equals(MongoStatsFields.TOTAL_MS_WRITE.toString())) {
-            return "" + timeUnit.transformMillis(getTotal_ms_write().getValueAsLong(intervalName));
+            return String.valueOf(timeUnit.transformMillis(getTotal_ms_write().getValueAsLong(intervalName)));
         }
         if (valueName.equals(MongoStatsFields.AVG_MS_WRITE.toString())) {
-            return "" + timeUnit.transformMillis(getAvg_ms_write().getValueAsDouble(intervalName));
+            return String.valueOf(timeUnit.transformMillis(getAvg_ms_write().getValueAsDouble(intervalName)));
         }
         if (valueName.equals(MongoStatsFields.LAST_MS_WRITE.toString())) {
-            return "" + timeUnit.transformMillis(getLast_ms_write().getValueAsDouble(intervalName));
+            return String.valueOf(timeUnit.transformMillis(getLast_ms_write().getValueAsDouble(intervalName)));
         }
         if (valueName.equals(MongoStatsFields.CURRENT_CONNECTIONS.toString())) {
             return getCurrent_connections().getValueAsString(intervalName);

--- a/moskito-extensions/moskito-notification-providers/pom.xml
+++ b/moskito-extensions/moskito-notification-providers/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
           <groupId>com.sun.jersey</groupId>
           <artifactId>jersey-client</artifactId>
-          <version>1.18</version>
+          <version>${jersey-version}</version>
       </dependency>
       <dependency>
 		<groupId>net.anotheria</groupId>

--- a/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationproviders/MailNotificationProvider.java
+++ b/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationproviders/MailNotificationProvider.java
@@ -49,7 +49,7 @@ public class MailNotificationProvider implements NotificationProvider {
 
 
     public MailNotificationProvider() {
-        recipients = new ArrayList<String>();
+        recipients = new ArrayList<>();
     }
 
     @Override

--- a/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationproviders/MailNotificationProvider.java
+++ b/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationproviders/MailNotificationProvider.java
@@ -101,7 +101,7 @@ public class MailNotificationProvider implements NotificationProvider {
                         log.error("Can't send message to " + r);
 
                 } catch (Exception e) {
-                    log.error("onNewAlert(" + alert + "), to:  " + r + ")", e);
+                    log.error("onNewAlert(" + alert + "), to:  " + r + ')', e);
                 }
             }
         } else {

--- a/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationproviders/MailgunNotificationProvider.java
+++ b/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationproviders/MailgunNotificationProvider.java
@@ -103,7 +103,7 @@ public class MailgunNotificationProvider implements NotificationProvider {
     public void configure(NotificationProviderConfig config) {
         try {
             String tokens[] = StringUtils.tokenize(config.getProperties().get(NotificationProviderConfigKey.RECIPIENTS.getKey()), ',');
-            recipients = new ArrayList<String>();
+            recipients = new ArrayList<>(tokens.length);
             for (String t : tokens) {
                 if (t.length() > 0)
                     recipients.add(t.trim());

--- a/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationproviders/ThresholdAlertConverter.java
+++ b/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationproviders/ThresholdAlertConverter.java
@@ -18,13 +18,13 @@ public class ThresholdAlertConverter {
      */
     public static String toPlainText(ThresholdAlert thresholdAlert) {
         String text = "Threshold alert:\n";
-        text += "Timestamp: "+thresholdAlert.getTimestamp()+"\n";
-        text += "ISO Timestamp: "+ NumberUtils.makeISO8601TimestampString(thresholdAlert.getTimestamp())+"\n";
-        text += "Threshold: "+thresholdAlert.getThreshold().getName()+"\n";
-        text += "OldStatus: "+thresholdAlert.getOldStatus()+"\n";
-        text += "NewStatus: "+thresholdAlert.getNewStatus()+"\n";
-        text += "OldValue: "+thresholdAlert.getOldValue()+"\n";
-        text += "NewValue: "+thresholdAlert.getNewValue()+"\n";
+        text += "Timestamp: "+thresholdAlert.getTimestamp()+ '\n';
+        text += "ISO Timestamp: "+ NumberUtils.makeISO8601TimestampString(thresholdAlert.getTimestamp())+ '\n';
+        text += "Threshold: "+thresholdAlert.getThreshold().getName()+ '\n';
+        text += "OldStatus: "+thresholdAlert.getOldStatus()+ '\n';
+        text += "NewStatus: "+thresholdAlert.getNewStatus()+ '\n';
+        text += "OldValue: "+thresholdAlert.getOldValue()+ '\n';
+        text += "NewValue: "+thresholdAlert.getNewValue()+ '\n';
         return text;
     }
 }

--- a/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationtemplate/AbstractMailTemplate.java
+++ b/moskito-extensions/moskito-notification-providers/src/main/java/net/anotheria/moskito/extensions/notificationtemplate/AbstractMailTemplate.java
@@ -19,7 +19,7 @@ public abstract class AbstractMailTemplate implements MailTemplate {
 	/**
 	 * Mail template parameters.
 	 */
-	private Map<String, Serializable> parameters = new HashMap<String, Serializable>();
+	private Map<String, Serializable> parameters = new HashMap<>();
 
 	/**
 	 * Static init block.

--- a/moskito-extensions/moskito-sampling-api/src/main/java/net/anotheria/moskito/extensions/sampling/endpoints/servlet/SamplingServlet.java
+++ b/moskito-extensions/moskito-sampling-api/src/main/java/net/anotheria/moskito/extensions/sampling/endpoints/servlet/SamplingServlet.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * TODO comment this class
@@ -45,7 +46,7 @@ public class SamplingServlet extends MoskitoHttpServlet{
 			throw new IllegalArgumentException("mapperId parameter '"+PARAM_STAT_MAPPER_ID+"' may not be empty.");
 		}
 
-		HashMap<String, String> parameters = new HashMap<String, String>();
+		Map<String, String> parameters = new HashMap<>();
 		Enumeration<String> paramNames = req.getParameterNames();
 		while(paramNames.hasMoreElements()){
 			String pName = paramNames.nextElement();

--- a/moskito-extensions/pom.xml
+++ b/moskito-extensions/pom.xml
@@ -7,7 +7,6 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>net.anotheria</groupId>
   <artifactId>moskito-extensions</artifactId>
   <version>2.7.5-SNAPSHOT</version>
   <name>moskito extensions aggregator</name>

--- a/moskito-inspect-standalone/pom.xml
+++ b/moskito-inspect-standalone/pom.xml
@@ -195,11 +195,6 @@
                     <artifactId>moskito-inspect-jersey</artifactId>
                     <version>${project.version}</version>
                 </dependency>
-                <dependency>
-                    <groupId>net.anotheria</groupId>
-                    <artifactId>moskitoplugins</artifactId>
-                    <version>${moskitoplugins-version}</version>
-                </dependency>
             </dependencies>
             <build>
                 <plugins>
@@ -212,15 +207,6 @@
                                     <groupId>net.anotheria</groupId>
                                     <artifactId>moskito-webui</artifactId>
                                     <version>${moskito-webui-version}</version>
-                                    <type>jar</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/tmp</outputDirectory>
-                                    <includes>moskito/**,**/*.jsp</includes>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>net.anotheria</groupId>
-                                    <artifactId>moskitoplugins</artifactId>
-                                    <version>${moskitoplugins-version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/tmp</outputDirectory>

--- a/moskito-inspect-standalone/pom.xml
+++ b/moskito-inspect-standalone/pom.xml
@@ -11,10 +11,6 @@
 	<version>2.7.5-SNAPSHOT</version>
 	<name>MoSKito Inspect Standalone Application</name>
 	<packaging>war</packaging>
-	<properties>
-		<moskito-webui-version>${project.version}</moskito-webui-version>
-        <aspectj.version>1.8.2</aspectj.version>
-	</properties>
 
 	<dependencies>
 		<dependency>
@@ -104,7 +100,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${aspectj-maven-plugin.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.aspectj</groupId>
@@ -125,8 +121,8 @@
                         </aspectLibrary>
                     </aspectLibraries>
 					<complianceLevel>1.7</complianceLevel>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${source-version}</source>
+                    <target>${target-version}</target>
                 </configuration>
                 <executions>
                     <execution>
@@ -192,9 +188,6 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            <properties>
-                <moskitoplugins-version>1.0.0-SNAPSHOT</moskitoplugins-version>
-            </properties>
             <dependencies>
                 <!-- Add jersey rest interface -->
                 <dependency>

--- a/moskito-inspect-standalone/pom.xml
+++ b/moskito-inspect-standalone/pom.xml
@@ -164,6 +164,11 @@
                     <artifactId>moskito-inspect-jersey</artifactId>
                     <version>${project.version}</version>
                 </dependency>
+                <dependency>
+                    <groupId>net.anotheria</groupId>
+                    <artifactId>moskitoplugins</artifactId>
+                    <version>${moskitoplugins-version}</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>
@@ -176,6 +181,15 @@
                                     <groupId>net.anotheria</groupId>
                                     <artifactId>moskito-webui</artifactId>
                                     <version>${moskito-webui-version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/tmp</outputDirectory>
+                                    <includes>moskito/**,**/*.jsp</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>net.anotheria</groupId>
+                                    <artifactId>moskitoplugins</artifactId>
+                                    <version>${moskitoplugins-version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/tmp</outputDirectory>

--- a/moskito-inspect-standalone/pom.xml
+++ b/moskito-inspect-standalone/pom.xml
@@ -100,37 +100,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>${aspectj-maven-plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.aspectj</groupId>
-                        <artifactId>aspectjrt</artifactId>
-                        <version>${aspectj.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.aspectj</groupId>
-                        <artifactId>aspectjtools</artifactId>
-                        <version>${aspectj.version}</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <aspectLibraries>
-                        <aspectLibrary>
-                            <groupId>net.anotheria</groupId>
-                            <artifactId>moskito-aop</artifactId>
-                        </aspectLibrary>
-                    </aspectLibraries>
-					<complianceLevel>1.7</complianceLevel>
-                    <source>${source-version}</source>
-                    <target>${target-version}</target>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 		</plugins>
 	</build>

--- a/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/AbstractInterceptor.java
+++ b/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/AbstractInterceptor.java
@@ -150,7 +150,7 @@ public abstract class AbstractInterceptor<T extends IStats> {
     private void createMethodLevelAccumulators(OnDemandStatsProducer<T> producer, Method method) {
         //several @Accumulators in accumulators holder
         Accumulates accAnnotationHolderMethods = (Accumulates) method.getAnnotation(Accumulates.class);
-        if (accAnnotationHolderMethods != null && accAnnotationHolderMethods.value() != null) {
+        if (accAnnotationHolderMethods != null) {
             Accumulate[] accAnnotations  = accAnnotationHolderMethods.value();
             for (Accumulate accAnnotation : accAnnotations) {
                 createAccumulator(
@@ -180,7 +180,7 @@ public abstract class AbstractInterceptor<T extends IStats> {
     private void createClassLevelAccumulators(OnDemandStatsProducer<T> producer, Class producerClass) {
         //several @Accumulators in accumulators holder
         Accumulates accAnnotationHolder = AnnotationUtils.findAnnotation(producerClass, Accumulates.class);//(Accumulates) producerClass.getAnnotation(Accumulates.class);
-        if (accAnnotationHolder != null && accAnnotationHolder.value() != null) {
+        if (accAnnotationHolder != null) {
             Accumulate[] accAnnotations  = accAnnotationHolder.value();
             for (Accumulate accAnnotation : accAnnotations) {
                 createAccumulator(
@@ -226,7 +226,7 @@ public abstract class AbstractInterceptor<T extends IStats> {
                 accName!=null && !accName.isEmpty() && statsName != null && !statsName.isEmpty()){
 
             AccumulatorDefinition definition = new AccumulatorDefinition();
-            if (annotation.name() != null && annotation.name().length() >0) {
+            if (annotation.name().length() > 0) {
                 definition.setName(annotation.name());
             }else{
                 definition.setName(accName);

--- a/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/AbstractInterceptor.java
+++ b/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/AbstractInterceptor.java
@@ -203,13 +203,13 @@ public abstract class AbstractInterceptor<T extends IStats> {
 
     private String formAccumulatorNameForMethod(final OnDemandStatsProducer<T> producer, final Accumulate annotation, final Method m) {
         if (producer != null && annotation != null && m != null)
-            return producer.getProducerId()+"."+m.getName()+"."+annotation.valueName()+"."+annotation.intervalName();
+            return producer.getProducerId()+ '.' +m.getName()+ '.' +annotation.valueName()+ '.' +annotation.intervalName();
         return "";
     }
 
     private String formAccumulatorNameForClass(final OnDemandStatsProducer<T> producer, final Accumulate annotation) {
         if (producer != null && annotation != null)
-            return producer.getProducerId()+"."+annotation.valueName()+"."+annotation.intervalName();
+            return producer.getProducerId()+ '.' +annotation.valueName()+ '.' +annotation.intervalName();
         return "";
     }
 

--- a/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/monitor/MonitorInterceptor.java
+++ b/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/monitor/MonitorInterceptor.java
@@ -135,8 +135,10 @@ public class MonitorInterceptor extends AbstractInterceptor<ServiceStats> implem
                 methodStats.notifyError();
             if (currentStep != null)
                 currentStep.setAborted();
-            if (tracePassingOfThisProducer)
-                call.append(" ERR "+t.getMessage());
+            if (tracePassingOfThisProducer) {
+                call.append(" ERR ");
+                call.append(t.getMessage());
+            }
 
             throw t;
         } finally {

--- a/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/monitor/MonitorInterceptor.java
+++ b/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/monitor/MonitorInterceptor.java
@@ -136,8 +136,7 @@ public class MonitorInterceptor extends AbstractInterceptor<ServiceStats> implem
             if (currentStep != null)
                 currentStep.setAborted();
             if (tracePassingOfThisProducer) {
-                call.append(" ERR ");
-                call.append(t.getMessage());
+                call.append(" ERR ").append(t.getMessage());
             }
 
             throw t;

--- a/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/monitor/MonitorInterceptor.java
+++ b/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/monitor/MonitorInterceptor.java
@@ -62,7 +62,8 @@ public class MonitorInterceptor extends AbstractInterceptor<ServiceStats> implem
         final Monitor annotation = getAnnotationFromContext(ctx, Monitor.class);
 
         // if producer id isn't specified by client - use class name
-        final String producerId = annotation.producerId().isEmpty() ? method.getDeclaringClass().getSimpleName() : annotation.producerId();
+        String className = method.getDeclaringClass().getSimpleName();
+        final String producerId = annotation.producerId().isEmpty() ? className : annotation.producerId();
 
         final OnDemandStatsProducer onDemandProducer = getProducer(method.getDeclaringClass(), producerId, annotation.category(), annotation.subsystem(), true);
 
@@ -82,8 +83,11 @@ public class MonitorInterceptor extends AbstractInterceptor<ServiceStats> implem
         final TracedCall aRunningTrace = RunningTraceContainer.getCurrentlyTracedCall();
         TraceStep currentStep = null;
         CurrentlyTracedCall currentTrace = aRunningTrace.callTraced() ? (CurrentlyTracedCall) aRunningTrace : null;
+        String methodName = method.getName();
         if (currentTrace != null) {
-            currentStep = currentTrace.startStep(TracingUtil.buildCall(method, parameters), onDemandProducer);
+            String optionalPrefix = null;
+            String call = TracingUtil.buildCall(className, methodName, parameters, optionalPrefix).toString();
+            currentStep = currentTrace.startStep(call, onDemandProducer);
         }
 
         TracerRepository tracerRepository = TracerRepository.getInstance();
@@ -107,7 +111,7 @@ public class MonitorInterceptor extends AbstractInterceptor<ServiceStats> implem
 
         StringBuilder call = null;
         if (currentTrace != null || tracePassingOfThisProducer) {
-            call = TracingUtil.buildCall(producerId, method.getName(), parameters, tracePassingOfThisProducer ? Tracers.getCallName(trace) : null);
+            call = TracingUtil.buildCall(producerId, methodName, parameters, tracePassingOfThisProducer ? Tracers.getCallName(trace) : null);
         }
         if (currentTrace != null) {
             currentStep = currentTrace.startStep(call.toString(), onDemandProducer);

--- a/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/monitor/MonitorInterceptor.java
+++ b/moskito-integration/moskito-cdi/src/main/java/net/anotheria/moskito/integration/cdi/monitor/MonitorInterceptor.java
@@ -158,7 +158,7 @@ public class MonitorInterceptor extends AbstractInterceptor<ServiceStats> implem
                 try {
                     currentStep.appendToCall(" = " + TracingUtil.parameter2string(ret));
                 } catch (Throwable t) {
-                    currentStep.appendToCall(" = ERR: " + t.getMessage() + " (" + t.getClass() + ")");
+                    currentStep.appendToCall(" = ERR: " + t.getMessage() + " (" + t.getClass() + ')');
                 }
             }
 

--- a/moskito-integration/moskito-ehcache/src/main/java/net/anotheria/moskito/integration/ehcache/EhcacheStats.java
+++ b/moskito-integration/moskito-ehcache/src/main/java/net/anotheria/moskito/integration/ehcache/EhcacheStats.java
@@ -326,10 +326,10 @@ public class EhcacheStats extends AbstractStats {
             throw new AssertionError("Value name can not be null or empty");
         }
         if (valueName.equals(AVERAGE_GET_TIME)) {
-            return "" + timeUnit.transformMillis(getAverageGetTime().getValueAsDouble(intervalName));
+            return String.valueOf(timeUnit.transformMillis(getAverageGetTime().getValueAsDouble(intervalName)));
         }
         if (valueName.equals(AVERAGE_SEARCH_TIME)) {
-            return "" + timeUnit.transformMillis(getAverageSearchTime().getValueAsLong(intervalName));
+            return String.valueOf(timeUnit.transformMillis(getAverageSearchTime().getValueAsLong(intervalName)));
         }
         if (valueName.equals(STATISTICS_ACCURACY)) {
             return getStatisticsAccuracy().getValueAsString(intervalName);

--- a/moskito-integration/moskito-ehcache/src/test/java/net/anotheria/moskito/integration/ehcache/MonitoredEhcacheTest.java
+++ b/moskito-integration/moskito-ehcache/src/test/java/net/anotheria/moskito/integration/ehcache/MonitoredEhcacheTest.java
@@ -44,7 +44,7 @@ public class MonitoredEhcacheTest {
         /* adding 100 elements into cache */
         List<Element> elements = new LinkedList<Element>();
         for(int i = 1; i <= 100; i++) {
-            elements.add(new Element("element"+i, ""+i));
+            elements.add(new Element("element"+i, String.valueOf(i)));
         }
 
         /* let's hit the cache for 150 times */

--- a/moskito-integration/moskito-sql/pom.xml
+++ b/moskito-integration/moskito-sql/pom.xml
@@ -17,7 +17,24 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${aspectj-maven-plugin.version}</version>
+                <configuration>
+                    <complianceLevel>${aspectj-maven-plugin.complianceLevel}</complianceLevel>
+                    <source>${source-version}</source>
+                    <target>${target-version}</target>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjrt</artifactId>
+                        <version>${aspectj.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjtools</artifactId>
+                        <version>${aspectj.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <goals>
@@ -27,8 +44,8 @@
                             <!-- use this goal to weave all your test classes -->
                         </goals>
                         <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
+                            <source>${source-version}</source>
+                            <target>${target-version}</target>
                         </configuration>
                     </execution>
                 </executions>

--- a/moskito-integration/moskito-sql/pom.xml
+++ b/moskito-integration/moskito-sql/pom.xml
@@ -17,38 +17,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>${aspectj-maven-plugin.version}</version>
-                <configuration>
-                    <complianceLevel>${aspectj-maven-plugin.complianceLevel}</complianceLevel>
-                    <source>${source-version}</source>
-                    <target>${target-version}</target>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.aspectj</groupId>
-                        <artifactId>aspectjrt</artifactId>
-                        <version>${aspectj.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.aspectj</groupId>
-                        <artifactId>aspectjtools</artifactId>
-                        <version>${aspectj.version}</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <!-- use this goal to weave all your main classes -->
-                            <goal>test-compile</goal>
-                            <!-- use this goal to weave all your test classes -->
-                        </goals>
-                        <configuration>
-                            <source>${source-version}</source>
-                            <target>${target-version}</target>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/moskito-integration/moskito-sql/pom.xml
+++ b/moskito-integration/moskito-sql/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.6.11</version>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>

--- a/moskito-integration/moskito-sql/src/main/java/net/anotheria/moskito/sql/callingAspect/ConnectionCallAspect.java
+++ b/moskito-integration/moskito-sql/src/main/java/net/anotheria/moskito/sql/callingAspect/ConnectionCallAspect.java
@@ -45,7 +45,7 @@ public class ConnectionCallAspect {
 			"|| call(boolean java.sql.Statement.execute(String,int[]))" +
 			"|| call(boolean java.sql.Statement.execute(String,String[]))" +
 			"|| call(void java.sql.Statement.addBatch(String))" +
-			")" +
+			')' +
 			"&& args(smt) && !within(net.anotheria.moskito.sql.aspect.ConnectionCallAspect)";
 	/**
 	 * Query failed.

--- a/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/InterceptTest.java
+++ b/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/InterceptTest.java
@@ -11,7 +11,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.sql.Connection;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * SQL intercept test.

--- a/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/MatcherValueDAO.java
+++ b/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/MatcherValueDAO.java
@@ -260,7 +260,7 @@ public class MatcherValueDAO implements DAO{
 				int rows = ps.executeUpdate();
 				if (rows!=1)
 					throw new DAOException("Create failed, updated rows: "+rows);
-				MatcherValueVO newMatchervalue = new MatcherValueVO(""+nextId);
+				MatcherValueVO newMatchervalue = new MatcherValueVO(String.valueOf(nextId));
 				newMatchervalue.copyAttributesFrom(matchervalue);
 				con.commit();
 				return newMatchervalue;
@@ -300,7 +300,7 @@ public class MatcherValueDAO implements DAO{
 					int rows = ps.executeUpdate();
 					if (rows!=1)
 						throw new DAOException("Create failed, updated rows: "+rows);
-					MatcherValueVO newMatchervalue = new MatcherValueVO(""+nextId);
+					MatcherValueVO newMatchervalue = new MatcherValueVO(String.valueOf(nextId));
 					newMatchervalue.copyAttributesFrom(matchervalue);
 					ret.add(newMatchervalue);
 				}

--- a/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/MatcherValueRowMapper.java
+++ b/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/MatcherValueRowMapper.java
@@ -24,7 +24,7 @@ public class MatcherValueRowMapper extends RowMapper<MatcherValue> {
     public MatcherValue map(ResultSet row) throws RowMapperException {
         try {
             long id = row.getLong(1);
-            MatcherValue ret = new MatcherValueVO("" + id);
+            MatcherValue ret = new MatcherValueVO(String.valueOf(id));
             ret.setType(row.getInt(2));
             ret.setValue(row.getString(3));
             ret.setMatcherId(row.getString(4));

--- a/moskito-integration/pom.xml
+++ b/moskito-integration/pom.xml
@@ -7,7 +7,6 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>net.anotheria</groupId>
   <artifactId>moskito-integration</artifactId>
   <version>2.7.5-SNAPSHOT</version>
   <name>moskito integration aggregator</name>

--- a/moskito-web/pom.xml
+++ b/moskito-web/pom.xml
@@ -48,11 +48,5 @@
   		<artifactId>ano-prise</artifactId>  
   		<scope>test</scope>
   	</dependency>
-  <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-	  <scope>test</scope>
-  </dependency>
-
   </dependencies>
 </project>

--- a/moskito-web/src/main/java/net/anotheria/moskito/web/filters/DebugRequestFilter.java
+++ b/moskito-web/src/main/java/net/anotheria/moskito/web/filters/DebugRequestFilter.java
@@ -94,7 +94,8 @@ public class DebugRequestFilter implements Filter {
             StringBuilder parameterValues = new StringBuilder();
             if (entry.getValue() != null)
                 for (String value : entry.getValue()) {
-                    parameterValues.append(value + " ");
+                    parameterValues.append(value);
+                    parameterValues.append(' ');
                 }
             logger.info(entry.getKey() + " = " + parameterValues);
         }

--- a/moskito-web/src/main/java/net/anotheria/moskito/web/filters/GenericMonitoringFilter.java
+++ b/moskito-web/src/main/java/net/anotheria/moskito/web/filters/GenericMonitoringFilter.java
@@ -68,15 +68,14 @@ public class GenericMonitoringFilter implements Filter {
 	private FilterStats getCaseStats(String caseName, OnDemandStatsProducer<FilterStats> producer){
 		if (caseName == null)
 			return null;
-		try{
-			if (caseName!=null)
-				return producer.getStats(caseName);
-		}catch(OnDemandStatsProducerException e){
-			log.debug("Couldn't get stats for case : "+caseName+", probably limit reached");
+		try {
+			return producer.getStats(caseName);
+		} catch (OnDemandStatsProducerException e) {
+			log.debug("Couldn't get stats for case : " + caseName + ", probably limit reached");
 			try {
 				return producer.getStats(OTHER);
 			} catch (OnDemandStatsProducerException e1) {
-				log.error("This can't happen, 'OtherStats' aka "+OTHER+" doesn't exists in producer for case "+caseName);
+				log.error("This can't happen, 'OtherStats' aka " + OTHER + " doesn't exists in producer for case " + caseName);
 			}
 		}
 		return null;

--- a/moskito-web/src/main/java/net/anotheria/moskito/web/filters/JourneyFilter.java
+++ b/moskito-web/src/main/java/net/anotheria/moskito/web/filters/JourneyFilter.java
@@ -89,8 +89,8 @@ public class JourneyFilter implements Filter{
 			if (req.getPathInfo()!=null)
 				url += req.getPathInfo();
 			if (req.getQueryString()!=null)
-				url += "?"+req.getQueryString();
-			RunningTraceContainer.startTracedCall(record.getUseCaseName()+"-"+url);
+				url += '?' +req.getQueryString();
+			RunningTraceContainer.startTracedCall(record.getUseCaseName()+ '-' +url);
 		}
 		try{
 			chain.doFilter(sreq, sres);

--- a/moskito-web/src/main/java/net/anotheria/moskito/web/filters/JourneyRecord.java
+++ b/moskito-web/src/main/java/net/anotheria/moskito/web/filters/JourneyRecord.java
@@ -42,6 +42,6 @@ class JourneyRecord implements Serializable {
 	}
 
 	public String getUseCaseName(){
-		return getName()+"-"+getRequestCount();
+		return getName()+ '-' +getRequestCount();
 	}
 }

--- a/moskito-web/src/main/java/net/anotheria/moskito/web/filters/JourneyStarterFilter.java
+++ b/moskito-web/src/main/java/net/anotheria/moskito/web/filters/JourneyStarterFilter.java
@@ -73,8 +73,8 @@ public class JourneyStarterFilter implements Filter{
 		if (req.getPathInfo()!=null)
 			url += req.getPathInfo();
 		if (req.getQueryString()!=null)
-			url += "?"+req.getQueryString();
-		RunningTraceContainer.startTracedCall(record.getUseCaseName() + "-" + url);
+			url += '?' +req.getQueryString();
+		RunningTraceContainer.startTracedCall(record.getUseCaseName() + '-' + url);
 
 		try{
 			filterChain.doFilter(servletRequest, servletResponse);

--- a/moskito-web/src/main/java/net/anotheria/moskito/web/filters/JourneyStarterFilter.java
+++ b/moskito-web/src/main/java/net/anotheria/moskito/web/filters/JourneyStarterFilter.java
@@ -79,13 +79,11 @@ public class JourneyStarterFilter implements Filter{
 		try{
 			filterChain.doFilter(servletRequest, servletResponse);
 		}finally{
-			if (record!=null){
-				TracedCall last = RunningTraceContainer.endTrace();
-				journey.addUseCase((CurrentlyTracedCall)last);
+			TracedCall last = RunningTraceContainer.endTrace();
+			journey.addUseCase((CurrentlyTracedCall)last);
 
-				//removes the running use case to cleanup the thread local. Otherwise tomcat will be complaining...
-				RunningTraceContainer.cleanup();
-			}
+			//removes the running use case to cleanup the thread local. Otherwise tomcat will be complaining...
+			RunningTraceContainer.cleanup();
 		}
 
 	}

--- a/moskito-web/src/main/java/net/anotheria/moskito/web/session/SessionCountProducer.java
+++ b/moskito-web/src/main/java/net/anotheria/moskito/web/session/SessionCountProducer.java
@@ -73,7 +73,7 @@ public class SessionCountProducer extends AbstractBuiltInProducer<SessionCountSt
 	}
 	
 	@Override public String toString(){
-		return getProducerId()+" "+getStats();
+		return getProducerId()+ ' ' +getStats();
 		
 	}
 }

--- a/moskito-web/src/main/java/net/anotheria/moskito/web/session/SessionCountProducer.java
+++ b/moskito-web/src/main/java/net/anotheria/moskito/web/session/SessionCountProducer.java
@@ -34,7 +34,7 @@ public class SessionCountProducer extends AbstractBuiltInProducer<SessionCountSt
 		
 		stats = new SessionCountStats();
 		
-		statsList = new ArrayList<SessionCountStats>();
+		statsList = new ArrayList<>(1);
 		statsList.add(stats);
 		
 		IProducerRegistry reg = ProducerRegistryFactory.getProducerRegistryInstance();

--- a/moskito-webui/pom.xml
+++ b/moskito-webui/pom.xml
@@ -53,10 +53,6 @@
         </dependency>
         <dependency>
             <groupId>net.anotheria</groupId>
-            <artifactId>ano-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.anotheria</groupId>
             <artifactId>ano-plass</artifactId>
         </dependency>
         <dependency>
@@ -143,7 +139,7 @@
             </exclusions>
         </dependency>
 
-        <!-- readded explicit dependency to dozer for form mapping -->
+        <!-- re-added explicit dependency to dozer for form mapping -->
         <dependency>
             <groupId>net.anotheria</groupId>
             <artifactId>ano-util</artifactId>

--- a/moskito-webui/pom.xml
+++ b/moskito-webui/pom.xml
@@ -130,7 +130,6 @@
         <dependency>
             <groupId>net.anotheria</groupId>
             <artifactId>ano-prise</artifactId>
-            <version>2.1.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.anotheria</groupId>

--- a/moskito-webui/pom.xml
+++ b/moskito-webui/pom.xml
@@ -10,9 +10,6 @@
     <artifactId>moskito-webui</artifactId>
     <version>2.7.5-SNAPSHOT</version>
     <name>moskito embedded web user interface</name>
-    <properties>
-        <distributeme.version>2.3.0</distributeme.version>
-    </properties>
 
     <build>
 

--- a/moskito-webui/pom.xml
+++ b/moskito-webui/pom.xml
@@ -156,12 +156,11 @@
             <version>5.1</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.springframework</groupId>
                     <artifactId>spring</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/MoSKitoWebUIContext.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/MoSKitoWebUIContext.java
@@ -50,11 +50,11 @@ public class MoSKitoWebUIContext {
 	}
 
 	private void copyFromAnotherContext(MoSKitoWebUIContext anotherContext){
-		currentSession      = anotherContext.currentSession;
-		currentTimeUnit     = anotherContext.currentTimeUnit;
+		currentSession = anotherContext.currentSession;
+		currentTimeUnit = anotherContext.currentTimeUnit;
 		currentIntervalName = anotherContext.currentIntervalName;
 		analyzeProducerCallsSortType = anotherContext.analyzeProducerCallsSortType;
-		attributes = (HashMap<String,Serializable>)((HashMap<String,Serializable>)anotherContext.attributes).clone();
+		attributes = new HashMap<>(anotherContext.attributes);
 	}
 
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/MoSKitoWebUIContext.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/MoSKitoWebUIContext.java
@@ -39,7 +39,7 @@ public class MoSKitoWebUIContext {
 	/**
 	 * Simple container map to pass attributes between modules.
 	 */
-	private Map<String,Serializable> attributes = new HashMap<String, Serializable>();
+	private Map<String,Serializable> attributes = new HashMap<>();
 
 	public HttpSession getCurrentSession() {
 		return currentSession;

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/MoskitoUIFilter.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/MoskitoUIFilter.java
@@ -46,7 +46,7 @@ public class MoskitoUIFilter extends MAFFilter{
 			String computerName = NetUtils.getComputerName();
 			config.getServletContext().setAttribute("servername", computerName==null ? "Unknown" : computerName);
 		}catch(Exception e){
-			log.error("init("+config+")", e);
+			log.error("init("+config+ ')', e);
 		}
 
 		String pathToImagesParameter = config.getInitParameter("pathToImages");

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/GenerateChartAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/GenerateChartAction.java
@@ -86,7 +86,7 @@ public class GenerateChartAction implements Action {
             chart.addLineDefinition(new OfflineChartLineDefinition(accData.getName()));
             chartSourceData[i++] = accData;
 
-            log.debug("Adding on pos " + (i - 1) + " " + accData);
+            log.debug("Adding on pos " + (i - 1) + ' ' + accData);
         }
 
         if (accNames.length > 1) fileName = "CombinedChart";

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/GenerateChartAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/GenerateChartAction.java
@@ -94,7 +94,7 @@ public class GenerateChartAction implements Action {
 
         log.debug("Preparing data");
         //prepare data
-        Map<String, TemporaryPoint> tmppoints = new HashMap(chartSourceData.length);
+        Map<String, TemporaryPoint> tmppoints = new HashMap<>(chartSourceData.length);
         for (i = 0; i < chartSourceData.length; i++) {
             AccumulatedSingleGraphAO accData = chartSourceData[i];
             log.debug("Processing " + accData + " with values " + accData.getData());

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/GenerateChartAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/GenerateChartAction.java
@@ -44,7 +44,7 @@ public class GenerateChartAction implements Action {
 
         AccumulatorAPI accumulatorAPI = APILookupUtility.getAccumulatorAPI();
 
-        if (isZip == null || (isZip != null && isZip.equals("false"))) {
+        if (isZip == null || isZip.equals("false")) {
             ChartData offlineChart = getOfflineChart(namesParam, accumulatorAPI);
 
             res.setContentType(PNG_CONTENT_TYPE);
@@ -53,7 +53,7 @@ public class GenerateChartAction implements Action {
             res.getOutputStream().write(offlineChart.getData());
 
         }
-        else if (isZip != null && isZip.equals("true")) {
+        else if (isZip.equals("true")) {
             String[] names = StringUtils.tokenize(namesParam, ',');
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/GenerateChartAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/GenerateChartAction.java
@@ -94,7 +94,7 @@ public class GenerateChartAction implements Action {
 
         log.debug("Preparing data");
         //prepare data
-        Map<String, TemporaryPoint> tmppoints = new HashMap();
+        Map<String, TemporaryPoint> tmppoints = new HashMap(chartSourceData.length);
         for (i = 0; i < chartSourceData.length; i++) {
             AccumulatedSingleGraphAO accData = chartSourceData[i];
             log.debug("Processing " + accData + " with values " + accData.getData());

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/ShowAccumulatorsAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/ShowAccumulatorsAction.java
@@ -122,7 +122,7 @@ public class ShowAccumulatorsAction extends BaseAccumulatorsAction {
 		
 		req.setAttribute("accumulators", getAccumulatorAPI().getAccumulatorDefinitions());
 		
-		List<String> ids = new ArrayList<String>();
+		List<String> ids = new ArrayList<>();
 		
 		Enumeration<?> names = req.getParameterNames();
 		while(names.hasMoreElements()){
@@ -133,8 +133,9 @@ public class ShowAccumulatorsAction extends BaseAccumulatorsAction {
 				req.setAttribute(name+"_set", Boolean.TRUE);
 			}
 		}
-		
-		if (ids.size()>0){
+
+		int numberOfIds = ids.size();
+		if (numberOfIds > 0){
 
 			if (mode == AccumulatorSetMode.COMBINED || mode == AccumulatorSetMode.NORMALIZED){
 				MultilineChartAO mchartAO = null;
@@ -149,8 +150,8 @@ public class ShowAccumulatorsAction extends BaseAccumulatorsAction {
 			} else {
 
 				//create multiple graphs with one line each.
-				List<AccumulatedSingleGraphAO> singleGraphDataBeans = new ArrayList<AccumulatedSingleGraphAO>(ids.size());
-				List<String> accumulatorsNames = new ArrayList<String>();
+				List<AccumulatedSingleGraphAO> singleGraphDataBeans = new ArrayList<>(numberOfIds);
+				List<String> accumulatorsNames = new ArrayList<>(numberOfIds);
 
 				for (String id : ids) {
 					final AccumulatorAO accumulator = getAccumulatorAPI().getAccumulator(id);

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/ShowAccumulatorsAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/action/ShowAccumulatorsAction.java
@@ -203,7 +203,7 @@ public class ShowAccumulatorsAction extends BaseAccumulatorsAction {
 			//step2 recalculate
 			for (int i=0; i<values.size(); i++){
 				float newValue = (valueCopy.get(i)-min)*multiplier;
-				values.get(i).setValue(name, ""+newValue);
+				values.get(i).setValue(name, String.valueOf(newValue));
 			}
 		}
 	}

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatedSingleGraphAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatedSingleGraphAO.java
@@ -14,6 +14,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 /**
  * This bean contains data for a single graph in multiple graph mode.
  * @author lrosenberg
@@ -42,9 +44,9 @@ public class AccumulatedSingleGraphAO implements Serializable{
 	/**
 	 * This is a helper map that contains characters an accumulator name can contains, that are prohibited in js variables and therefore have to be mapped.
 	 */
-	private static final HashMap<String, String> jsReplaceMap;
+	private static final Map<String, String> jsReplaceMap;
 	static{
-		jsReplaceMap = new HashMap<String, String>();
+		jsReplaceMap = new HashMap<>(4);
 		jsReplaceMap.put(" ", "_");
 		jsReplaceMap.put("-", "_");
 		jsReplaceMap.put("+", "_");
@@ -53,7 +55,7 @@ public class AccumulatedSingleGraphAO implements Serializable{
 	
 	public AccumulatedSingleGraphAO(String aName){
 		name = aName;
-		data = new ArrayList<AccumulatedValueAO>();
+		data = new ArrayList<>();
 	}
 	
 	public String getName() {

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatedValueAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatedValueAO.java
@@ -47,7 +47,7 @@ public class AccumulatedValueAO implements Serializable, IComparable<Accumulated
 	
 	public AccumulatedValueAO(String aTimestamp){
 		timestamp = aTimestamp;
-		values = new ArrayList<String>();
+		values = new ArrayList<>();
 	}
 
 	public void addValue(String value) {

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatedValueAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatedValueAO.java
@@ -75,17 +75,17 @@ public class AccumulatedValueAO implements Serializable, IComparable<Accumulated
 		StringBuilder ret = new StringBuilder("[");
 		ret.append(numericTimestamp);
 		for (String s: values)
-			ret.append(",").append(s);
-		ret.append("]");
+			ret.append(',').append(s);
+		ret.append(']');
 		return ret.toString();
 	}
 
 	public String getJSONWithStringTimestamp(){
 		StringBuilder ret = new StringBuilder("[");
-		ret.append("\"").append(timestamp).append("\"");
+		ret.append('"').append(timestamp).append('"');
 		for (String s: values)
-			ret.append(",").append(s);
-		ret.append("]");
+			ret.append(',').append(s);
+		ret.append(']');
 		return ret.toString();
 	}
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPIImpl.java
@@ -225,8 +225,7 @@ public class AccumulatorAPIImpl extends AbstractMoskitoAPIImpl implements Accumu
 		//generally its not always a good idea to use subList, but since that list isn't reused,
 		//as in subList or subList of subList, its ok.
 		if (dataBeans.size()>maxValues) {
-			List<AccumulatedValueAO> shorterList = new ArrayList<AccumulatedValueAO>();
-			shorterList.addAll(dataBeans.subList(dataBeans.size() - maxValues, dataBeans.size()));
+			List<AccumulatedValueAO> shorterList = new ArrayList<AccumulatedValueAO>(dataBeans.subList(dataBeans.size() - maxValues, dataBeans.size()));
 			dataBeans = shorterList;
 		}
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPIImpl.java
@@ -17,6 +17,7 @@ import net.anotheria.util.sorter.StaticQuickSorter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of the AccumulatorAPI.
@@ -104,7 +105,7 @@ public class AccumulatorAPIImpl extends AbstractMoskitoAPIImpl implements Accumu
 	@Override
 	public List<AccumulatorDefinitionAO> getAccumulatorDefinitions() throws APIException {
 		List<Accumulator> accumulators = AccumulatorRepository.getInstance().getAccumulators();
-		List<AccumulatorDefinitionAO> ret = new ArrayList<AccumulatorDefinitionAO>();
+		List<AccumulatorDefinitionAO> ret = new ArrayList<>(accumulators.size());
 
 		for (Accumulator a : accumulators){
 			AccumulatorDefinitionAO bean = new AccumulatorDefinitionAO();
@@ -146,15 +147,15 @@ public class AccumulatorAPIImpl extends AbstractMoskitoAPIImpl implements Accumu
 		//TODO actually this limit is hardcoded, we should make it dynamic.
 		int maxValues = 200;
 
-		if (ids.size() == 0)
+		int numberOfIds = ids.size();
+		if (numberOfIds == 0)
 			throw new APIException("No accumulators selected");
 
-		List<AccumulatedValueAO> dataBeans = new ArrayList<AccumulatedValueAO>();
-		List<AccumulatedSingleGraphAO> singleGraphDataBeans = new ArrayList<AccumulatedSingleGraphAO>(ids.size());
+		List<AccumulatedSingleGraphAO> singleGraphDataBeans = new ArrayList<>(numberOfIds);
 
 		//prepare values
-		HashMap<Long, AccumulatedValuesBean> values = new HashMap<Long, AccumulatedValuesBean>();
-		List<String> accNames = new ArrayList<String>();
+		Map<Long, AccumulatedValuesBean> values = new HashMap<>(numberOfIds);
+		List<String> accNames = new ArrayList<>(numberOfIds);
 
 		for (String id : ids){
 			AccumulatorAO acc = getAccumulator(id);
@@ -179,7 +180,7 @@ public class AccumulatorAPIImpl extends AbstractMoskitoAPIImpl implements Accumu
 
 		//now check if the data is complete
 		//Stores last known values to allow filling in of missing values (combining 1m and 5m values)
-		HashMap<String, String> lastValue = new HashMap<String, String>();
+		Map<String, String> lastValue = new HashMap<>(accNames.size());
 
 		//filling last (or first) values.
 		for (String accName : accNames){
@@ -211,6 +212,7 @@ public class AccumulatorAPIImpl extends AbstractMoskitoAPIImpl implements Accumu
 		}
 
 		//now create final data
+		List<AccumulatedValueAO> dataBeans = new ArrayList<>(valuesList.size());
 		for(AccumulatedValuesBean avb : valuesList){
 			AccumulatedValueAO bean = new AccumulatedValueAO(avb.getTime());
 			bean.setIsoTimestamp(NumberUtils.makeISO8601TimestampString(avb.getTimestamp()));

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPIImpl.java
@@ -259,7 +259,7 @@ public class AccumulatorAPIImpl extends AbstractMoskitoAPIImpl implements Accumu
 			//step2 recalculate
 			for (int i=0; i<values.size(); i++){
 				float newValue = (valueCopy.get(i)-min)*multiplier;
-				values.get(i).setValue(name, ""+newValue);
+				values.get(i).setValue(name, String.valueOf(newValue));
 			}
 		}
 	}

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPIImpl.java
@@ -64,7 +64,7 @@ public class AccumulatorAPIImpl extends AbstractMoskitoAPIImpl implements Accumu
 	@Override public AccumulatorAO getAccumulatorByName(String name) throws APIException{
 		Accumulator acc = AccumulatorRepository.getInstance().getByName(name);
 		if (acc==null)
-			throw new IllegalArgumentException("Attempt to access non existing accumulator with name: '" +name+"'");
+			throw new IllegalArgumentException("Attempt to access non existing accumulator with name: '" +name+ '\'');
 		return new AccumulatorAO(acc);
 	}
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/bean/AccumulatedValuesBean.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/bean/AccumulatedValuesBean.java
@@ -27,7 +27,7 @@ public class AccumulatedValuesBean implements IComparable{
 	 */
 	public AccumulatedValuesBean(long aTimestamp){
 		timestamp = aTimestamp;
-		values = new HashMap<String, String>();
+		values = new HashMap<>();
 	}
 	
 	@Override public String toString(){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardAPIImpl.java
@@ -163,14 +163,8 @@ public class DashboardAPIImpl extends AbstractMoskitoAPIImpl implements Dashboar
 				DashboardChartAO bean = new DashboardChartAO();
 				if (cc.getCaption()!=null){
 					bean.setCaption(cc.getCaption());
-				}else{
-					String caption = "";
-					for (String acc : cc.getAccumulators()){
-						if (caption.length()!=0)
-							caption += " ";
-						caption += acc;
-					}
-					bean.setCaption(caption);
+				} else{
+					bean.setCaption(cc.buildCaption());
 				}
 
 				LinkedList<String> chartIds = new LinkedList<String>();

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardAPIImpl.java
@@ -195,15 +195,16 @@ public class DashboardAPIImpl extends AbstractMoskitoAPIImpl implements Dashboar
 
 	@Override
 	public List<String> getDashboardNames() throws APIException {
-		List<String> dashboardNames = new ArrayList<String>();
 		MoskitoConfiguration config = MoskitoConfigurationHolder.getConfiguration();
 		DashboardsConfig dashboardsConfig = config.getDashboardsConfig();
-		if (dashboardsConfig.getDashboards()!=null){
-			for (DashboardConfig dc : dashboardsConfig.getDashboards()){
+		DashboardConfig[] dashboards = dashboardsConfig.getDashboards();
+		if (dashboards != null){
+			List<String> dashboardNames = new ArrayList<>(dashboards.length);
+			for (DashboardConfig dc : dashboards){
 				dashboardNames.add(dc.getName());
 			}
+			return dashboardNames;
 		}
-		return dashboardNames;
-
+		return new ArrayList<>(0);
 	}
 }

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardAPIImpl.java
@@ -100,7 +100,7 @@ public class DashboardAPIImpl extends AbstractMoskitoAPIImpl implements Dashboar
 		MoskitoConfiguration config = getConfiguration();
 		DashboardsConfig dashboardsConfig = config.getDashboardsConfig();
 		if (dashboardsConfig == null || dashboardsConfig.getDashboards() == null ||dashboardsConfig.getDashboards().length == 0)
-			return Collections.EMPTY_LIST;
+			return Collections.emptyList();
 		LinkedList<DashboardDefinitionAO> ret = new LinkedList<DashboardDefinitionAO>();
 		for (DashboardConfig dashboardConfig : dashboardsConfig.getDashboards()){
 			DashboardDefinitionAO ao = new DashboardDefinitionAO();

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardChartDefinitionAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardChartDefinitionAO.java
@@ -14,7 +14,7 @@ import java.util.List;
 @XmlRootElement(name="chart")
 public class DashboardChartDefinitionAO implements Serializable{
 	private String caption;
-	private List<String> accumulatorNames = Collections.EMPTY_LIST;
+	private List<String> accumulatorNames = Collections.emptyList();
 
 	public List<String> getAccumulatorNames() {
 		return accumulatorNames;

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardDefinitionAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/api/DashboardDefinitionAO.java
@@ -18,8 +18,8 @@ public class DashboardDefinitionAO implements Serializable{
 	 * Name of the Dashboard.
 	 */
 	private String name;
-	private List<String> gauges = Collections.EMPTY_LIST;
-	private List<String> thresholds = Collections.EMPTY_LIST;
+	private List<String> gauges = Collections.emptyList();
+	private List<String> thresholds = Collections.emptyList();
 	private List<DashboardChartDefinitionAO> charts = new LinkedList<DashboardChartDefinitionAO>();
 
 	public List<String> getGauges() {

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/api/GaugeAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/api/GaugeAPIImpl.java
@@ -101,7 +101,7 @@ public class GaugeAPIImpl extends AbstractMoskitoAPIImpl implements GaugeAPI {
 			if (g.getName().equals(name))
 				return g;
 		}
-		throw new APIException("Can't find gauge configuration for '"+name+"'");
+		throw new APIException("Can't find gauge configuration for '"+name+ '\'');
 
 	}
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/api/GaugeAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/api/GaugeAPIImpl.java
@@ -152,7 +152,7 @@ public class GaugeAPIImpl extends AbstractMoskitoAPIImpl implements GaugeAPI {
 		}
 
 		//ok, its not a constant
-		IStatsProducer producer = null;
+		IStatsProducer<?> producer = null;
 		try{
 			producer = producerRegistryAPI.getProducer(config.getProducerName());
 		}catch(NoSuchProducerException e){
@@ -160,7 +160,7 @@ public class GaugeAPIImpl extends AbstractMoskitoAPIImpl implements GaugeAPI {
 		}
 		if (producer == null )
 			return new StringValueAO(null, "no producer");
-		for (IStats s : (List<IStats>)producer.getStats()){
+		for (IStats s : producer.getStats()){
 			if (s.getName().equals(config.getStatName())){
 				String value = s.getValueByNameAsString(config.getValueName(), config.getIntervalName(), TimeUnit.valueOf(config.getTimeUnit()));
 				try {

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/api/GaugeAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/api/GaugeAPIImpl.java
@@ -48,7 +48,7 @@ public class GaugeAPIImpl extends AbstractMoskitoAPIImpl implements GaugeAPI {
 		if (defaultZonesConfig == null || defaultZonesConfig.length == 0){
 			defaultZones = createDefaultZones();
 		}else{
-			defaultZones = new ArrayList<GaugeZoneAO>();
+			defaultZones = new ArrayList<>(defaultZonesConfig.length);
 			for (GaugeZoneConfig zoneConfig : defaultZonesConfig){
 				defaultZones.add(zoneAOFromZoneConfig(zoneConfig));
 			}
@@ -60,7 +60,7 @@ public class GaugeAPIImpl extends AbstractMoskitoAPIImpl implements GaugeAPI {
 	 * @return
 	 */
 	private List<GaugeZoneAO> createDefaultZones(){
-		ArrayList<GaugeZoneAO> ret = new ArrayList<GaugeZoneAO>();
+		ArrayList<GaugeZoneAO> ret = new ArrayList<>(1);
 		GaugeZoneAO redZone = new GaugeZoneAO();
 		redZone.setColor("red");
 		redZone.setLeft(0.9f);

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/api/GaugeZoneAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/api/GaugeZoneAO.java
@@ -47,7 +47,7 @@ public class GaugeZoneAO implements Serializable{
 	}
 
 	@Override public String toString(){
-		return getColor()+": ["+left+", "+right+"]";
+		return getColor()+": ["+left+", "+right+ ']';
 	}
 
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/action/ShowJourneysAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/action/ShowJourneysAction.java
@@ -32,7 +32,7 @@ public class ShowJourneysAction extends BaseJourneyAction{
 		if (req.getServerPort()!=80 && req.getServerPort()!=443)
 			url += ":"+req.getServerPort();
 		if (!contextPath.startsWith("/"))
-			contextPath = "/"+contextPath;
+			contextPath = '/' +contextPath;
 		url += contextPath;
 		String url1 = url + "?mskJourney=start&mskJourneyName=";
 		String url2 = url + "?mskJourney=stop&mskJourneyName=";

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/AnalyzedProducerCallsMapAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/AnalyzedProducerCallsMapAO.java
@@ -32,7 +32,7 @@ public class AnalyzedProducerCallsMapAO implements Serializable {
 	
 	public AnalyzedProducerCallsMapAO(String aName){
 		name = aName;
-		beans = new HashMap<String, AnalyzedProducerCallsAO>();
+		beans = new HashMap<>();
 	}
 	
 	@Override public String toString(){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/AnalyzedProducerCallsMapAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/AnalyzedProducerCallsMapAO.java
@@ -36,7 +36,7 @@ public class AnalyzedProducerCallsMapAO implements Serializable {
 	}
 	
 	@Override public String toString(){
-		return name + " "+beans;
+		return name + ' ' +beans;
 	}
 
 	/**

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/JourneyAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/JourneyAPIImpl.java
@@ -102,7 +102,7 @@ public class JourneyAPIImpl extends AbstractMoskitoAPIImpl implements  JourneyAP
 		ret.setElements(container.getElements());
 
 		//check for duplicates
-		List<TracedCallDuplicateStepsAO> dupSteps = new ArrayList<TracedCallDuplicateStepsAO>();
+		List<TracedCallDuplicateStepsAO> dupSteps = new ArrayList<>();
 		Map<String,JourneyCallIntermediateContainer.ReversedCallHelper > stepsReversed = container.getReversedSteps();
 		for (Map.Entry<String, JourneyCallIntermediateContainer.ReversedCallHelper> entry : stepsReversed.entrySet()){
 			if (entry.getValue()!=null && entry.getValue().getPositions().size()>1){
@@ -161,15 +161,13 @@ public class JourneyAPIImpl extends AbstractMoskitoAPIImpl implements  JourneyAP
 
 	@Override
 	public List<AnalyzedProducerCallsMapAO> analyzeJourney(String journeyName) throws APIException {
-		List<AnalyzedProducerCallsMapAO> callsList = new ArrayList<AnalyzedProducerCallsMapAO>();
 		Journey journey = getJourneyByName(journeyName);
-
-
+		List<CurrentlyTracedCall> tracedCalls = journey.getTracedCalls();
+		List<AnalyzedProducerCallsMapAO> callsList = new ArrayList<>(tracedCalls.size() + 1);
 
 		AnalyzedProducerCallsMapAO overallCallsMap = new AnalyzedProducerCallsMapAO(journey.getName()+" - TOTAL");
 		callsList.add(overallCallsMap);
 
-		List<CurrentlyTracedCall> tracedCalls = journey.getTracedCalls();
 		for (CurrentlyTracedCall tc : tracedCalls){
 			if (tc==null){
 				log.warn("TracedCall is null!");

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/JourneyCallIntermediateContainer.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/JourneyCallIntermediateContainer.java
@@ -15,11 +15,11 @@ public class JourneyCallIntermediateContainer {
 	/**
 	 * The reversed map of steps used to determine duplicates.
 	 */
-	private Map<String, ReversedCallHelper> stepsReversed = new HashMap<String, ReversedCallHelper>();
+	private Map<String, ReversedCallHelper> stepsReversed = new HashMap<>();
 	/**
 	 * Element in this countainer.
 	 */
-	private List<TracedCallStepAO> elements = new ArrayList<TracedCallStepAO>();
+	private List<TracedCallStepAO> elements = new ArrayList<>();
 	/**
 	 * Counter.
 	 */
@@ -69,7 +69,7 @@ public class JourneyCallIntermediateContainer {
 	 *
 	 */
 	public static class ReversedCallHelper{
-		private List<String> positions = new ArrayList<String>();
+		private List<String> positions = new ArrayList<>();
 		private long timespent = 0;
 		private long duration = 0;
 		
@@ -101,7 +101,7 @@ public class JourneyCallIntermediateContainer {
 		/**
 		 * Holds known parents.
  		 */
-		private Map<Integer, Integer> parents = new HashMap<Integer, Integer>();
+		private Map<Integer, Integer> parents = new HashMap<>();
 		
 		private int getParentIdByLayer(int layer, String currentId){
 			int _currentId = Integer.parseInt(currentId);

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/TracedCallAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/TracedCallAO.java
@@ -30,7 +30,7 @@ public class TracedCallAO implements Serializable{
 	private List<TracedCallDuplicateStepsAO> duplicateSteps;
 	
 	public TracedCallAO(){
-		elements = new ArrayList<TracedCallStepAO>();
+		elements = new ArrayList<>();
 	}
 	
 	public long getCreated() {

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/TracedCallStepAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/api/TracedCallStepAO.java
@@ -61,7 +61,7 @@ public class TracedCallStepAO implements Serializable{
 
 
 	public TracedCallStepAO(){
-		children = new ArrayList<TracedCallStepAO>();
+		children = new ArrayList<>();
 	}
 	
 	public void addChild(TracedCallStepAO c){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/more/action/ShowConfigAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/more/action/ShowConfigAction.java
@@ -54,7 +54,7 @@ public class ShowConfigAction extends BaseAdditionalAction{
 
 		///thresholds
 		List<Threshold> thresholds = ThresholdRepository.getInstance().getThresholds();
-		ArrayList<String> thresholdStrings = new ArrayList<String>();
+		List<String> thresholdStrings = new ArrayList<>(thresholds.size());
 		for (Threshold t : thresholds){
 			String jsonT = gson.toJson(t.toConfigObject());
 			JsonElement jeT = jp.parse(jsonT);

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/more/action/ShowLibsAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/more/action/ShowLibsAction.java
@@ -49,7 +49,7 @@ public class ShowLibsAction extends BaseAdditionalAction{
 	public ActionCommand execute(ActionMapping mapping, FormBean formBean, HttpServletRequest req, HttpServletResponse res) throws Exception {
 
 		List<URL> classpath = getClassPathUrls(req.getContextPath());
-		List<LibAO> beans = new ArrayList<LibAO>();
+		List<LibAO> beans = new ArrayList<>(classpath.size());
 
 		for (URL url : classpath){
 			String fileName = url.getFile();
@@ -85,7 +85,7 @@ public class ShowLibsAction extends BaseAdditionalAction{
 		if (forTomcat6!=null && forTomcat6.size()>0)
 			return forTomcat6;
 		//add another lookup methods here.
-		return new ArrayList<URL>();
+		return new ArrayList<>(0);
 
 	}
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/BaseShowProducersAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/BaseShowProducersAction.java
@@ -56,10 +56,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Base action for producers presentation action.
@@ -88,9 +85,9 @@ public abstract class BaseShowProducersAction extends BaseMoskitoUIAction {
 	@Override
 	public ActionCommand execute(ActionMapping mapping, FormBean formBean, HttpServletRequest req, HttpServletResponse res) throws APIException{
 
-		Map<String, GraphDataBean> graphData = new HashMap<String, GraphDataBean>();
+		Map<String, GraphDataBean> graphData = new HashMap<>();
 
-		req.setAttribute("decorators", getDecoratedProducers(req, getProducers(req), graphData));
+		req.setAttribute("decorators", getDecoratedProducers(req,  getProducers(req), graphData));
 		req.setAttribute("graphDatas", graphData.values());
 
 		doCustomProcessing(req, res);
@@ -124,13 +121,13 @@ public abstract class BaseShowProducersAction extends BaseMoskitoUIAction {
 	//todo make separate method for graphData in future
 	protected List<ProducerDecoratorBean> getDecoratedProducers(HttpServletRequest req, List<ProducerAO> producers, Map<String, GraphDataBean> graphData){
 
-		Map<IDecorator, List<ProducerAO>> decoratorMap = new HashMap<IDecorator,List<ProducerAO>>();
+		Map<IDecorator, List<ProducerAO>> decoratorMap = new HashMap<>(producers.size());
 		for (ProducerAO producer : producers){
 			try{
 				IDecorator decorator = findOrCreateDecorator(producer);
 				List<ProducerAO> decoratoredProducers = decoratorMap.get(decorator);
 				if (decoratoredProducers == null){
-					decoratoredProducers = new ArrayList<ProducerAO>();
+					decoratoredProducers = new ArrayList<>();
 					decoratorMap.put(decorator, decoratoredProducers);
 
 					for(StatValueAO statBean : producer.getFirstStatsValues()){
@@ -145,9 +142,9 @@ public abstract class BaseShowProducersAction extends BaseMoskitoUIAction {
 			}
 		}
 
-		List<ProducerDecoratorBean> beans = new ArrayList<ProducerDecoratorBean>();
-
-		for (Map.Entry<IDecorator, List<ProducerAO>> entry : decoratorMap.entrySet()){
+		Set<Map.Entry<IDecorator, List<ProducerAO>>> entries = decoratorMap.entrySet();
+		List<ProducerDecoratorBean> beans = new ArrayList<>(entries.size());
+		for (Map.Entry<IDecorator, List<ProducerAO>> entry : entries){
 			IDecorator decorator = entry.getKey();
 			ProducerDecoratorBean b = new ProducerDecoratorBean();
 			b.setName(decorator.getName());

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/BaseShowProducersAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/BaseShowProducersAction.java
@@ -134,8 +134,8 @@ public abstract class BaseShowProducersAction extends BaseMoskitoUIAction {
 					decoratorMap.put(decorator, decoratoredProducers);
 
 					for(StatValueAO statBean : producer.getFirstStatsValues()){
-						String graphKey = decorator.getName()+"_"+statBean.getName();
-						GraphDataBean graphDataBean = new GraphDataBean(decorator.getName()+"_"+statBean.getJsVariableName(), statBean.getName());
+						String graphKey = decorator.getName()+ '_' +statBean.getName();
+						GraphDataBean graphDataBean = new GraphDataBean(decorator.getName()+ '_' +statBean.getJsVariableName(), statBean.getName());
 						graphData.put(graphKey, graphDataBean);
 					}
 				}
@@ -157,7 +157,7 @@ public abstract class BaseShowProducersAction extends BaseMoskitoUIAction {
 				try {
 					List<StatValueAO> values = p.getFirstStatsValues();
 					for (StatValueAO valueBean : values){
-						String graphKey = decorator.getName()+"_"+valueBean.getName();
+						String graphKey = decorator.getName()+ '_' +valueBean.getName();
 						GraphDataBean bean = graphData.get(graphKey); 
 						if (bean==null) {
 						    // FIXME!

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowAllProducersAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowAllProducersAction.java
@@ -59,7 +59,7 @@ public class ShowAllProducersAction extends BaseShowProducersAction{
 		if (nameFilter.length()==0)
 			return all;
 		nameFilter = nameFilter.toLowerCase();
-		ArrayList<ProducerAO> filtered = new ArrayList<ProducerAO>();
+		List<ProducerAO> filtered = new ArrayList<>();
 		for (ProducerAO p : all){
 			if (p.getProducerId().toLowerCase().startsWith(nameFilter)){
 				filtered.add(p);

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducerAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducerAction.java
@@ -93,7 +93,7 @@ public class ShowProducerAction extends BaseMoskitoUIAction {
 		//boolean filterZero = pFilterZero != null && pFilterZero.equalsIgnoreCase("true");
 
 		IDecorator decorator = getDecoratorRegistry().getDecorator(producer.getStatsClazzName());
-		Map<String, GraphDataBean> graphData = new HashMap<String, GraphDataBean>();
+		Map<String, GraphDataBean> graphData = new HashMap<>();
 
 
 		List<StatLineAO> allLines = producer.getLines();
@@ -109,7 +109,7 @@ public class ShowProducerAction extends BaseMoskitoUIAction {
 			}
 		}
 
-		List<StatDecoratorBean> beans = new ArrayList<StatDecoratorBean>();
+		List<StatDecoratorBean> beans = new ArrayList<>(1);
 		//sort
 
 		final StatDecoratorBean decoratorBean = new StatDecoratorBean();
@@ -154,8 +154,9 @@ public class ShowProducerAction extends BaseMoskitoUIAction {
 		final int cumulatedIndex = getCumulatedIndex(allStatLines);
 
 		// stats
-		final List<StatBean> statBeans = new ArrayList<>();
-		for (int i = 0; i < allStatLines.size(); i++) {
+		int allStatLinesSize = allStatLines.size();
+		final List<StatBean> statBeans = new ArrayList<>(allStatLinesSize);
+		for (int i = 0; i < allStatLinesSize; i++) {
 			if (i == cumulatedIndex)
 				continue;
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducerAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducerAction.java
@@ -100,8 +100,8 @@ public class ShowProducerAction extends BaseMoskitoUIAction {
 		for (StatLineAO statLine : allLines){
 			try{
 				for(StatValueAO statBean : statLine.getValues()){
-					String graphKey = decorator.getName()+"_"+statBean.getName();
-					GraphDataBean graphDataBean = new GraphDataBean(decorator.getName()+"_"+statBean.getJsVariableName(), statBean.getName());
+					String graphKey = decorator.getName()+ '_' +statBean.getName();
+					GraphDataBean graphDataBean = new GraphDataBean(decorator.getName()+ '_' +statBean.getJsVariableName(), statBean.getName());
 					graphData.put(graphKey, graphDataBean);
 				}
 			}catch(ArrayIndexOutOfBoundsException e){
@@ -221,7 +221,7 @@ public class ShowProducerAction extends BaseMoskitoUIAction {
 			final List<StatValueAO> statValues = line.getValues();
 
 			for (StatValueAO statValue : statValues) {
-				final String graphKey = decorator.getName() + "_" + statValue.getName();
+				final String graphKey = decorator.getName() + '_' + statValue.getName();
 				final GraphDataValueBean value = new GraphDataValueBean(line.getStatName(), statValue.getRawValue());
 
 				final GraphDataBean graphDataBean = graphData.get(graphKey);
@@ -269,7 +269,7 @@ public class ShowProducerAction extends BaseMoskitoUIAction {
 	}
 
 	@Override protected String getLinkToCurrentPage(HttpServletRequest req) {
-		return "mskShowProducer"+"?"+PARAM_PRODUCER_ID+"="+req.getParameter(PARAM_PRODUCER_ID);
+		return "mskShowProducer"+ '?' +PARAM_PRODUCER_ID+ '=' +req.getParameter(PARAM_PRODUCER_ID);
 	}
 
 	private StatBeanSortType getStatBeanSortType(StatDecoratorBean decoratorBean, HttpServletRequest req){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducersAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducersAction.java
@@ -70,7 +70,7 @@ public class ShowProducersAction extends BaseShowProducersAction{
 	
 	@Override
 	protected List<ProducerAO> getProducers(HttpServletRequest req)  throws APIException {
-		List<IProducerFilter> filters = new ArrayList<IProducerFilter>();
+		List<IProducerFilter> filters = new ArrayList<>(2);
 		String category = getCategoryParameter(req);
 		if(category != null && category.length() > 0)
 			filters.add(new CategoryFilter(category));

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducersAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducersAction.java
@@ -77,7 +77,7 @@ public class ShowProducersAction extends BaseShowProducersAction{
 		String subsystem = getSubsystemParameter(req);
 		if(subsystem!= null && subsystem.length() > 0)
 			filters.add(new SubsystemFilter(subsystem));
-		return getProducerAPI().getProducers(filters.toArray(new IProducerFilter[0]), getCurrentInterval(req), getCurrentUnit(req).getUnit());
+		return getProducerAPI().getProducers(filters.toArray(new IProducerFilter[filters.size()]), getCurrentInterval(req), getCurrentUnit(req).getUnit());
 	}
 	
 	@Override public String getPageTitle(HttpServletRequest req){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducersForSubsystemAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/action/ShowProducersForSubsystemAction.java
@@ -64,7 +64,7 @@ public class ShowProducersForSubsystemAction extends BaseShowProducersAction{
 	}
 
 	@Override public String getLinkToCurrentPage(HttpServletRequest req){
-		return "mskShowProducersBySubsystem?"+PARAM_SUBSYSTEM+"="+getSubsystemParameter(req);
+		return "mskShowProducersBySubsystem?"+PARAM_SUBSYSTEM+ '=' +getSubsystemParameter(req);
 	}
 
 }

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/api/ProducerAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/api/ProducerAPIImpl.java
@@ -45,10 +45,10 @@ public class ProducerAPIImpl extends AbstractMoskitoAPIImpl implements ProducerA
 	 * Called after the configuration has been read.
 	 */
 	private void apiAfterConfiguration(){
-		List<ProducerFilter> newProducerFilters = new ArrayList<ProducerFilter>();
 		ProducerFilterConfig filterConfig[] = WebUIConfig.getInstance().getFilters();
 		if (filterConfig==null || filterConfig.length==0)
 			return;
+		List<ProducerFilter> newProducerFilters = new ArrayList<>(filterConfig.length);
 		for (ProducerFilterConfig pfc : filterConfig){
 			try {
 				ProducerFilter filter = (ProducerFilter)Class.forName(pfc.getClazzName()).newInstance();
@@ -182,7 +182,7 @@ public class ProducerAPIImpl extends AbstractMoskitoAPIImpl implements ProducerA
 	}
 
 	private List<ProducerAO> filterProducersAndConvertToAO(List<IStatsProducer> producers, String intervalName, TimeUnit timeUnit){
-		ArrayList<ProducerAO> ret = new ArrayList<ProducerAO>();
+		List<ProducerAO> ret = new ArrayList<>();
 		for (IStatsProducer<?> p : producers){
 			boolean mayPass = true;
 			for (ProducerFilter filter : producerFilters){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/api/ProducerAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/api/ProducerAPIImpl.java
@@ -129,7 +129,7 @@ public class ProducerAPIImpl extends AbstractMoskitoAPIImpl implements ProducerA
 	}
 
 	private List<ProducerAO> convertStatsProducerListToAO(List<IStatsProducer> producers, String intervalName, TimeUnit timeUnit){
-		LinkedList<ProducerAO> ret = new LinkedList<ProducerAO>();
+		LinkedList<ProducerAO> ret = new LinkedList<>();
 		for (IStatsProducer p : producers){
 			ret.add(convertStatsProducerToAO(p, intervalName, timeUnit));
 		}

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/api/UnitCountAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/api/UnitCountAO.java
@@ -88,6 +88,6 @@ public class UnitCountAO implements Serializable{
 	}
 
 	@Override public String toString(){
-		return unitName+"="+unitCount;
+		return unitName+ '=' +unitCount;
 	}
 }

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/api/filters/InternalProducerFilter.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/api/filters/InternalProducerFilter.java
@@ -24,7 +24,7 @@ public class InternalProducerFilter implements ProducerFilter {
 	private final HashSet<String> internalProducerNames;
 
 	public InternalProducerFilter(){
-		internalProducerNames = new HashSet<String>();
+		internalProducerNames = new HashSet<>(9);
 		internalProducerNames.add(ProducerAPI.class.getSimpleName());
 		internalProducerNames.add(ThresholdAPI.class.getSimpleName());
 		internalProducerNames.add(AccumulatorAPI.class.getSimpleName());

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/action/ShowExplanationsAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/action/ShowExplanationsAction.java
@@ -30,9 +30,9 @@ public class ShowExplanationsAction extends BaseMoskitoUIAction{
 	@Override
 	public ActionCommand execute(ActionMapping mapping, FormBean formBean, HttpServletRequest req, HttpServletResponse res) {
 
-		List<DecoratorExplanationBean> beans = new ArrayList<DecoratorExplanationBean>();
 		List<IDecorator> decorators = DecoratorRegistryFactory.getDecoratorRegistry().getDecorators();
 		decorators = StaticQuickSorter.sort(decorators, new DummySortType());
+		List<DecoratorExplanationBean> beans = new ArrayList<>(decorators.size());
 		for (IDecorator d : decorators){
 			DecoratorExplanationBean bean = new DecoratorExplanationBean();
 			bean.setName(d.getName());

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/AdditionalFunctionalityAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/AdditionalFunctionalityAPIImpl.java
@@ -59,7 +59,7 @@ public class AdditionalFunctionalityAPIImpl extends AbstractMoskitoAPIImpl imple
 			MoskitoPlugin plugin = PluginRepository.getInstance().getPlugin(s);
 
 			try{
-				ao.setDescription(""+plugin);
+				ao.setDescription(String.valueOf(plugin));
 			}catch(Exception e){
 				ao.setDescription("Error: "+e.getMessage());
 			}

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/AdditionalFunctionalityAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/AdditionalFunctionalityAPIImpl.java
@@ -51,7 +51,7 @@ public class AdditionalFunctionalityAPIImpl extends AbstractMoskitoAPIImpl imple
 	@Override
 	public List<PluginAO> getPlugins() throws APIException {
 		List<String> pluginNames = PluginRepository.getInstance().getPluginNames();
-		ArrayList<PluginAO> ret = new ArrayList<PluginAO>();
+		List<PluginAO> ret = new ArrayList<>(pluginNames.size());
 		for (String s : pluginNames){
 			PluginAO ao = new PluginAO();
 
@@ -102,7 +102,7 @@ public class AdditionalFunctionalityAPIImpl extends AbstractMoskitoAPIImpl imple
 	@Override public List<MBeanWrapperAO> getMBeans() throws APIException{
 		try{
 			List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
-			List<MBeanWrapperAO> beans = new ArrayList<MBeanWrapperAO>();
+			List<MBeanWrapperAO> beans = new ArrayList<>(servers.size());
 
 			for (MBeanServer s : servers){
 				Set<ObjectInstance> instances = s.queryMBeans(null, null);
@@ -143,7 +143,7 @@ public class AdditionalFunctionalityAPIImpl extends AbstractMoskitoAPIImpl imple
 	 */
 	private List<MBeanAttributeWrapperAO> convert(final MBeanAttributeInfo[] infos,
 												final MBeanServer server, final ObjectName name) {
-		final List<MBeanAttributeWrapperAO> res = new ArrayList<MBeanAttributeWrapperAO>();
+		final List<MBeanAttributeWrapperAO> res = new ArrayList<>(infos.length);
 
 		for (final MBeanAttributeInfo info : infos) {
 			Object value = "-";

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/AbstractDecoratorBean.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/AbstractDecoratorBean.java
@@ -79,11 +79,11 @@ public abstract class AbstractDecoratorBean implements IComparable{
 	}
 	
 	public String getSortByParameterName(){
-		return "p"+StringUtils.capitalize(name)+"SortBy";
+		return 'p' +StringUtils.capitalize(name)+"SortBy";
 	}
 
 	public String getSortOrderParameterName(){
-		return "p"+StringUtils.capitalize(name)+"SortOrder";
+		return 'p' +StringUtils.capitalize(name)+"SortOrder";
 	}
 
 	public String getDecoratorNameForCss(){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/GraphDataBean.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/GraphDataBean.java
@@ -25,7 +25,7 @@ public class GraphDataBean {
 	public GraphDataBean(String aJsVariableName, String aCaption){
 		caption = aCaption;
 		jsVariableName = aJsVariableName;
-		values = new ArrayList<GraphDataValueBean>();
+		values = new ArrayList<>();
 	}
 	
 	public void addValue(GraphDataValueBean value){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/GraphDataValueBean.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/GraphDataValueBean.java
@@ -33,6 +33,6 @@ public class GraphDataValueBean {
 	}
 	
 	public String getJsValue(){
-		return "['"+name+"',"+value+"]";
+		return "['"+name+"',"+value+ ']';
 	}
 }

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/LabelValueBean.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/LabelValueBean.java
@@ -42,6 +42,6 @@ public class LabelValueBean {
 	}
 
 	@Override public String toString(){
-		return getLabel()+" "+getValue();
+		return getLabel()+ ' ' +getValue();
 	}
 }

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/StatDecoratorBean.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/bean/StatDecoratorBean.java
@@ -56,7 +56,7 @@ public class StatDecoratorBean extends AbstractDecoratorBean {
 	 * Creates a new StatDecoratorBean.
 	 */
 	public StatDecoratorBean(){
-		stats = new ArrayList<StatBean>();
+		stats = new ArrayList<>();
 	}
 
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/resource/ReplyObject.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/resource/ReplyObject.java
@@ -31,7 +31,7 @@ public class ReplyObject {
 	 * Map with results object.
 	 */
 	@XmlElement
-	private HashMap<String, Object> results = new HashMap<String, Object>();
+	private HashMap<String, Object> results = new HashMap<>();
 
 	/**
 	 * Creates a new empty result object.

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/resource/ReplyObjectWriter.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/resource/ReplyObjectWriter.java
@@ -68,11 +68,11 @@ public class ReplyObjectWriter implements MessageBodyWriter<ReplyObject> {
 			for (Map.Entry entry : resultSet){
 				String sectionName = entry.getKey().toString();
 				//System.out.println("TO WRITE : "+entry.getValue()+", "+entry.getValue().getClass());
-				entityStream.write(("<"+sectionName+">").getBytes());
+				entityStream.write(('<' +sectionName+ '>').getBytes());
 				if (entry.getValue() instanceof List){
 					writeList((List)entry.getValue(), m, entityStream);
 				}
-				entityStream.write(("</"+sectionName+">").getBytes());
+				entityStream.write(("</"+sectionName+ '>').getBytes());
 			}
 
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threads/api/ThreadAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threads/api/ThreadAPIImpl.java
@@ -28,7 +28,7 @@ public class ThreadAPIImpl extends AbstractMoskitoAPIImpl implements ThreadAPI {
 	public List<ThreadInfoAO> getThreadInfos() throws APIException {
 		ThreadMXBean mxBean = ManagementFactory.getThreadMXBean();
 		long ids[] = mxBean.getAllThreadIds();
-		ArrayList<ThreadInfoAO> infos = new ArrayList<ThreadInfoAO>();
+		List<ThreadInfoAO> infos = new ArrayList<>(ids.length);
 		for (long id : ids){
 			infos.add(new ThreadInfoAO(mxBean.getThreadInfo(id)));
 		}

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/action/EditThresholdAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/action/EditThresholdAction.java
@@ -10,6 +10,7 @@ import net.anotheria.moskito.webui.threshold.api.ThresholdDefinitionAO;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +34,7 @@ public class EditThresholdAction extends BaseThresholdsAction{
 		request.setAttribute("thresholdId", thresholdId);
 
 		List<ThresholdConditionGuard> guards =  getThresholdAPI().getGuardsForThreshold(thresholdId);
-		HashMap<ThresholdStatus, String> guardValues = new HashMap<ThresholdStatus, String>();
+		Map<ThresholdStatus, String> guardValues = new EnumMap<>(ThresholdStatus.class);
 		for (ThresholdConditionGuard g : guards){
 			//we only support barrier guards for now.
 			if (g instanceof BarrierPassGuard){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdAPIImpl.java
@@ -16,10 +16,7 @@ import net.anotheria.moskito.webui.shared.api.AbstractMoskitoAPIImpl;
 import net.anotheria.util.NumberUtils;
 import net.anotheria.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 /**
  * TODO comment this class
@@ -30,8 +27,9 @@ import java.util.List;
 public class ThresholdAPIImpl extends AbstractMoskitoAPIImpl implements ThresholdAPI{
 	@Override
 	public List<ThresholdAlertAO> getAlerts() {
-		ArrayList<ThresholdAlertAO> aBeans = new ArrayList<ThresholdAlertAO>();
-		for (ThresholdAlert alert : AlertHistory.INSTANCE.getAlerts()){
+		List<ThresholdAlert> alerts = AlertHistory.INSTANCE.getAlerts();
+		List<ThresholdAlertAO> aBeans = new ArrayList<>(alerts.size());
+		for (ThresholdAlert alert : alerts){
 			ThresholdAlertAO alertBean = new ThresholdAlertAO();
 			alertBean.setId(alert.getThreshold().getId());
 			alertBean.setName(alert.getThreshold().getName());
@@ -202,7 +200,7 @@ public class ThresholdAPIImpl extends AbstractMoskitoAPIImpl implements Threshol
 	@Override
 	public List<ThresholdStatusAO> getThresholdStatuses() throws APIException {
 		List<Threshold> thresholds = ThresholdRepository.getInstance().getThresholds();
-		ArrayList<ThresholdStatusAO> ret = new ArrayList<ThresholdStatusAO>();
+		List<ThresholdStatusAO> ret = new ArrayList<>(thresholds.size());
 
 		for (Threshold t : thresholds){
 			ThresholdStatusAO statusAO = new ThresholdStatusAO();
@@ -231,11 +229,11 @@ public class ThresholdAPIImpl extends AbstractMoskitoAPIImpl implements Threshol
 	public List<ThresholdStatusAO> getThresholdStatuses(String ... names) throws APIException {
 		if (names==null)
 			return getThresholdStatuses();
-		HashSet<String> nameSet = new HashSet<String>();
+		Set<String> nameSet = new HashSet<>(names.length);
 		Collections.addAll(nameSet, names);
 
 		List<Threshold> thresholds = ThresholdRepository.getInstance().getThresholds();
-		ArrayList<ThresholdStatusAO> ret = new ArrayList<ThresholdStatusAO>();
+		List<ThresholdStatusAO> ret = new ArrayList<>(thresholds.size());
 
 		for (Threshold t : thresholds){
 			if (!nameSet.contains(t.getName()))
@@ -265,7 +263,7 @@ public class ThresholdAPIImpl extends AbstractMoskitoAPIImpl implements Threshol
 	@Override
 	public List<ThresholdDefinitionAO> getThresholdDefinitions() throws APIException {
 		List<Threshold> thresholds = ThresholdRepository.getInstance().getThresholds();
-		ArrayList<ThresholdDefinitionAO> ret = new ArrayList<ThresholdDefinitionAO>();
+		List<ThresholdDefinitionAO> ret = new ArrayList<>(thresholds.size());
 		for (Threshold t : thresholds){
 			ret.add(definition2AO(t));
 		}

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdAPIImpl.java
@@ -17,6 +17,7 @@ import net.anotheria.util.NumberUtils;
 import net.anotheria.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -231,8 +232,7 @@ public class ThresholdAPIImpl extends AbstractMoskitoAPIImpl implements Threshol
 		if (names==null)
 			return getThresholdStatuses();
 		HashSet<String> nameSet = new HashSet<String>();
-		for (String n : names)
-			nameSet.add(n);
+		Collections.addAll(nameSet, names);
 
 		List<Threshold> thresholds = ThresholdRepository.getInstance().getThresholds();
 		ArrayList<ThresholdStatusAO> ret = new ArrayList<ThresholdStatusAO>();

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdAPIImpl.java
@@ -77,7 +77,7 @@ public class ThresholdAPIImpl extends AbstractMoskitoAPIImpl implements Threshol
 
 	@Override
 	public void updateThreshold(String thresholdId, ThresholdPO po) throws APIException{
-		Threshold oldThreshold = ThresholdRepository.getInstance().getById(thresholdId);
+		Threshold oldThreshold =  ThresholdRepository.getInstance().getById(thresholdId);
 		ThresholdDefinition td = oldThreshold.getDefinition();
 		td.setName(po.getName());
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdDefinitionAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdDefinitionAO.java
@@ -60,7 +60,7 @@ public class ThresholdDefinitionAO implements Serializable{
 	private TimeUnit timeUnit;
 	
 	public ThresholdDefinitionAO(){
-		guards = new ArrayList<ThresholdConditionGuard>();
+		guards = new ArrayList<>();
 	}
 	
 	public void addGuard(ThresholdConditionGuard aGuard){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdDefinitionAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdDefinitionAO.java
@@ -133,7 +133,7 @@ public class ThresholdDefinitionAO implements Serializable{
 
 	@Override
 	public String toString() {
-		return id+"/"+producerName+"/"+statName+"/"+valueName+"/"+valueName;
+		return id+ '/' +producerName+ '/' +statName+ '/' +valueName+ '/' +valueName;
 	}
 
 	public TimeUnit getTimeUnit() {

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdStatusAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/api/ThresholdStatusAO.java
@@ -119,7 +119,7 @@ public class ThresholdStatusAO implements IComparable, Serializable{
 	}
 	
 	@Override public String toString(){
-		return getName()+" "+getStatus()+" "+getTimestamp()+" "+getDescription()+" "+getValue();
+		return getName()+ ' ' +getStatus()+ ' ' +getTimestamp()+ ' ' +getDescription()+ ' ' +getValue();
 	}
 	@Override
 	public int compareTo(IComparable anotherObject, int method) {

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/tracers/action/CreateTracerAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/tracers/action/CreateTracerAction.java
@@ -19,7 +19,7 @@ public class CreateTracerAction extends BaseTracersAction{
 	public ActionCommand execute(ActionMapping actionMapping, FormBean formBean, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception {
 		String producerId = httpServletRequest.getParameter(PARAM_PRODUCER_ID);
 		getTracerAPI().createTracer(producerId);
-		httpServletResponse.sendRedirect("mskShowProducer?"+PARAM_PRODUCER_ID+"="+ URLEncoder.encode(producerId, "UTF-8"));
+		httpServletResponse.sendRedirect("mskShowProducer?"+PARAM_PRODUCER_ID+ '=' + URLEncoder.encode(producerId, "UTF-8"));
 		return null;
 	}
 }

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/tracers/api/TracerAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/tracers/api/TracerAPIImpl.java
@@ -62,7 +62,7 @@ public class TracerAPIImpl extends AbstractMoskitoAPIImpl implements TracerAPI{
 		LinkedList<TraceAO> ret = new LinkedList<TraceAO>();
 		for (Trace t : traces){
 			TraceAO ao  = new TraceAO();
-			ao.setId(""+t.getId());
+			ao.setId(String.valueOf(t.getId()));
 			ao.setCall(t.getCall());
 			ao.setElements(Arrays.asList(t.getElements()));
 			ao.setDuration(timeUnit.transformNanos(t.getDuration()));

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/APILookupUtility.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/APILookupUtility.java
@@ -158,13 +158,13 @@ public class APILookupUtility {
 			Method m = constantsClass.getMethod("getServiceId");
 			serviceId = (String)m.invoke(null);
 		}catch(ClassNotFoundException e){
-			throw new AssertionError("Can not find supporting classes for "+targetClass+" " + e.getMessage());
+			throw new AssertionError("Can not find supporting classes for "+targetClass+ ' ' + e.getMessage());
 		} catch (NoSuchMethodException e) {
-			throw new AssertionError("Can not find supporting classes or methods for "+targetClass+" " + e.getMessage());
+			throw new AssertionError("Can not find supporting classes or methods for "+targetClass+ ' ' + e.getMessage());
 		} catch (InvocationTargetException e) {
-			throw new AssertionError("Can not obtain service id "+targetClass+" " + e.getMessage());
+			throw new AssertionError("Can not obtain service id "+targetClass+ ' ' + e.getMessage());
 		} catch (IllegalAccessException e) {
-			throw new AssertionError("Can not obtain service id "+targetClass+" " + e.getMessage());
+			throw new AssertionError("Can not obtain service id "+targetClass+ ' ' + e.getMessage());
 		}
 
 		Class<? extends T> remoteStubClass = null;

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/APILookupUtility.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/APILookupUtility.java
@@ -182,7 +182,7 @@ public class APILookupUtility {
 		ConcurrentMap<Class<? extends API>, API> stubsByInterface = remotes.get(ri);
 		if (stubsByInterface==null){
 			ConcurrentHashMap<Class<? extends API>, API> newStubsByInterface = new ConcurrentHashMap<>(0);
-			ConcurrentMap old = remotes.putIfAbsent(ri, newStubsByInterface);
+			ConcurrentMap<Class<? extends API>, API> old = remotes.putIfAbsent(ri, newStubsByInterface);
 			stubsByInterface = old == null ? newStubsByInterface : old;
 		}
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/APILookupUtility.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/APILookupUtility.java
@@ -37,7 +37,7 @@ public class APILookupUtility {
 	/**
 	 * A map with all remote instance.
 	 */
-	private static ConcurrentMap<RemoteInstance, ConcurrentMap<Class<? extends API>, API>> remotes = new ConcurrentHashMap<RemoteInstance, ConcurrentMap<Class<? extends API>,API>>();
+	private static ConcurrentMap<RemoteInstance, ConcurrentMap<Class<? extends API>, API>> remotes = new ConcurrentHashMap<>(1);
 
 	/**
 	 * Currently configured ConnectivityMode (local or remote).
@@ -181,7 +181,7 @@ public class APILookupUtility {
 		RemoteInstance ri = getCurrentRemoteInstance();
 		ConcurrentMap<Class<? extends API>, API> stubsByInterface = remotes.get(ri);
 		if (stubsByInterface==null){
-			ConcurrentHashMap<Class<? extends API>, API> newStubsByInterface = new ConcurrentHashMap<Class<? extends API>, API>();
+			ConcurrentHashMap<Class<? extends API>, API> newStubsByInterface = new ConcurrentHashMap<>(0);
 			ConcurrentMap old = remotes.putIfAbsent(ri, newStubsByInterface);
 			stubsByInterface = old == null ? newStubsByInterface : old;
 		}

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/ChartEngine.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/ChartEngine.java
@@ -23,11 +23,9 @@ public enum ChartEngine {
 
 	private ChartEngine(String... someNames){
 		names = new ArrayList<>(someNames.length);
-		if (someNames!=null){
-			for (String s :someNames){
-				names.add(s.toLowerCase());
-			}
-		}
+		for (String s :someNames){
+            names.add(s.toLowerCase());
+        }
 	}
 
 	public static ChartEngine getChartEngine(String aName){

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/ChartEngine.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/ChartEngine.java
@@ -22,7 +22,7 @@ public enum ChartEngine {
 	private List<String> names;
 
 	private ChartEngine(String... someNames){
-		names = new ArrayList<String>();
+		names = new ArrayList<>(someNames.length);
 		if (someNames!=null){
 			for (String s :someNames){
 				names.add(s.toLowerCase());

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/RemoteInstance.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/RemoteInstance.java
@@ -51,7 +51,7 @@ public class RemoteInstance implements Serializable{
 	}
 
 	public String toString(){
-		return getName()+"@"+getHost()+":"+getPort();
+		return getName()+ '@' +getHost()+ ':' +getPort();
 	}
 
 	/**
@@ -59,7 +59,7 @@ public class RemoteInstance implements Serializable{
 	 * @return
 	 */
 	public String getSelectKey(){
-		return getHost()+"-"+getPort();
+		return getHost()+ '-' +getPort();
 	}
 
 	/**

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/offlinecharts/OfflineChartGeneratorImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/offlinecharts/OfflineChartGeneratorImpl.java
@@ -111,7 +111,7 @@ public class OfflineChartGeneratorImpl implements OfflineChartGenerator{
 
         private double getPointY(String s) {
             int toG = 1000000000;
-            return !s.equals("") ? Double.parseDouble(s)/ toG : 0;
+            return !s.isEmpty() ? Double.parseDouble(s)/ toG : 0;
         }
 
     }

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/offlinecharts/OfflineChartGeneratorImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/offlinecharts/OfflineChartGeneratorImpl.java
@@ -69,10 +69,10 @@ public class OfflineChartGeneratorImpl implements OfflineChartGenerator{
 
     private class ChartAxes {
         // data for x axis
-        private List<Date> xData = new ArrayList<Date>();
+        private List<Date> xData = new ArrayList<>();
 
         //List with data for y axis
-        private List<List<Double>>  yDataList = new LinkedList<List<Double>>();
+        private List<List<Double>>  yDataList = new LinkedList<>();
 
         public ChartAxes(int lineAmounts) {
             for (int i = 0; i < lineAmounts; i++) {

--- a/moskito-webui/src/main/resources/moskito/ext/tablesorter/docs/example-option-sort-order.html
+++ b/moskito-webui/src/main/resources/moskito/ext/tablesorter/docs/example-option-sort-order.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-us">
 <head>
-	<title>jQuery plugin: Tablesorter 2.0 - Set a initi
+	<title>jQuery plugin: Tablesorter 2.0 - Set a initi</title>
 	<link rel="stylesheet" href="css/jq.css" type="text/css" media="print, projection, screen" />
 	<link rel="stylesheet" href="../themes/blue/style.css" type="text/css" id="" media="print, projection, screen" />
 	<script type="text/javascript" src="../jquery-latest.js"></script>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
 		<aspectj-maven-plugin.complianceLevel>1.7</aspectj-maven-plugin.complianceLevel>
 		<moskito-webui-version>${project.version}</moskito-webui-version>
 		<distributeme.version>2.3.0</distributeme.version>
-		<moskitoplugins-version>1.0.0-SNAPSHOT</moskitoplugins-version>
 	</properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,12 +97,12 @@
 			<dependency>
 				<groupId>org.aspectj</groupId>
 				<artifactId>aspectjrt</artifactId>
-				<version>1.7.4</version>
+				<version>${aspectj.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.aspectj</groupId>
 				<artifactId>aspectjtools</artifactId>
-				<version>1.7.4</version>
+				<version>${aspectj.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
 				<artifactId>jsr311-api</artifactId>
 				<version>1.1.1</version>
 			</dependency>
+			<dependency>
+				<groupId>org.hamcrest</groupId>
+				<artifactId>hamcrest-core</artifactId>
+				<version>1.3</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>net.anotheria</groupId>
 	<artifactId>moskito</artifactId>
 	<version>2.7.5-SNAPSHOT</version>
 	<name>MoSKito</name>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.hamcrest</groupId>
-				<artifactId>hamcrest-core</artifactId>
+				<artifactId>hamcrest-all</artifactId>
 				<version>1.3</version>
 			</dependency>
 		</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,18 @@
 		<module>moskito-integration</module>
 		<module>moskito-extensions</module>
 		<module>moskito-inspect-standalone</module>
-  </modules>
+	</modules>
 
 	<properties>
 		<jersey-version>1.18.1</jersey-version>
         <source-version>1.7</source-version>
         <target-version>1.7</target-version>
-
+		<aspectj.version>1.8.7</aspectj.version>
+		<aspectj-maven-plugin.version>1.8</aspectj-maven-plugin.version>
+		<aspectj-maven-plugin.complianceLevel>1.7</aspectj-maven-plugin.complianceLevel>
+		<moskito-webui-version>${project.version}</moskito-webui-version>
+		<distributeme.version>2.3.0</distributeme.version>
+		<moskitoplugins-version>1.0.0-SNAPSHOT</moskitoplugins-version>
 	</properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 		<aspectj-maven-plugin.complianceLevel>1.7</aspectj-maven-plugin.complianceLevel>
 		<moskito-webui-version>${project.version}</moskito-webui-version>
 		<distributeme.version>2.3.0</distributeme.version>
+		<moskitoplugins-version>1.0.0-SNAPSHOT</moskitoplugins-version>
 	</properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -143,4 +143,44 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>aspectj-maven-plugin</artifactId>
+					<version>${aspectj-maven-plugin.version}</version>
+					<configuration>
+						<complianceLevel>${aspectj-maven-plugin.complianceLevel}</complianceLevel>
+						<source>${source-version}</source>
+						<target>${target-version}</target>
+					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>org.aspectj</groupId>
+							<artifactId>aspectjrt</artifactId>
+							<version>${aspectj.version}</version>
+						</dependency>
+						<dependency>
+							<groupId>org.aspectj</groupId>
+							<artifactId>aspectjtools</artifactId>
+							<version>${aspectj.version}</version>
+						</dependency>
+					</dependencies>
+					<executions>
+						<execution>
+							<goals>
+								<goal>compile</goal>
+								<goal>test-compile</goal>
+							</goals>
+							<configuration>
+								<source>${source-version}</source>
+								<target>${target-version}</target>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 </project>


### PR DESCRIPTION
Due to an incompatibility with the aspectj maven plugin version 1.4, you cannot build Moskito AOP and the SQL integration with a Java 8 compiler. Since Java 7 is no longer supported broadly by Oracle, please consider this update to the newest plugin version (1.8) and the aspectj compiler 1.8.7.

I also tried to centralize some versioning properties to the parent POM to deny multiple versions of some dependencies within the Moskito project.

Thanks again for your support and this great tool!