### PR TITLE
Locale independent decimal number formatting

### DIFF
--- a/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/DoubleValueAO.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/decorators/value/DoubleValueAO.java
@@ -34,11 +34,11 @@
  */	
 package net.anotheria.moskito.core.decorators.value;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+
 import net.anotheria.util.BasicComparable;
 import net.anotheria.util.sorter.IComparable;
-
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 
 /**
  * Stat value bean for double values.
@@ -54,11 +54,21 @@ public class DoubleValueAO extends StatValueAO {
 	 * Cached string representation.
 	 */
 	private String doubleAsString;
-	
+
+	private static DecimalFormat decimalFormat = createDecimalFormat();
+
+	private static DecimalFormat createDecimalFormat() {
+		DecimalFormat decimalFormat = new DecimalFormat("0.000");
+		DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
+		decimalFormatSymbols.setDecimalSeparator('.');
+		decimalFormat.setDecimalFormatSymbols(decimalFormatSymbols);
+		return decimalFormat;
+	}
+
 	/**
 	 * Creates a new DoubleValueAO.
-	 * @param name
-	 * @param aValue
+	 * @param name identifies the value
+	 * @param aValue the value itself
 	 */
 	public DoubleValueAO(String name, double aValue){
 		super(name);
@@ -67,7 +77,6 @@ public class DoubleValueAO extends StatValueAO {
 		else
 			doubleValue = aValue;
 
-		DecimalFormat decimalFormat = new DecimalFormat("0.000");
 		doubleAsString = decimalFormat.format(doubleValue);
 	}
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/value/DoubleValueAOTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/value/DoubleValueAOTest.java
@@ -1,5 +1,7 @@
 package net.anotheria.moskito.core.decorators.value;
 
+import java.util.Locale;
+
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -144,7 +146,15 @@ public class DoubleValueAOTest {
         assertFormatting(Math.PI, "3.142");
     }
 
-    public void assertFormatting(double doubleValue, String expected) {
+	@Test
+	public void ignoreLocaleSettings() {
+		Locale defaultLocale = Locale.getDefault();
+		Locale.setDefault(Locale.GERMAN);
+		assertFormatting(Double.MAX_VALUE, "9223372036854776.000");
+		Locale.setDefault(defaultLocale);
+	}
+
+    private void assertFormatting(double doubleValue, String expected) {
         DoubleValueAO doubleValueAO = new DoubleValueAO("name", doubleValue);
         String returnValue = doubleValueAO.getValue();
         assertThat(returnValue, is(expected));


### PR DESCRIPTION
To ensure the locale is ignored during formatting of double values, please merge this fix.