### PR TITLE
Max Memory and Double values in Gauges

### DIFF
--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/AbstractMemoryPoolStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/AbstractMemoryPoolStats.java
@@ -59,6 +59,8 @@ public abstract class AbstractMemoryPoolStats extends AbstractStats implements I
 			return String.valueOf(getMaxCommited(intervalName));
 		if (valueName.equals("max"))
 			return String.valueOf(getMax(intervalName));
+		if (valueName.equals("max mb"))
+			return String.valueOf(getMax(intervalName) / MB);		
 		if (valueName.equals("free"))
 			return String.valueOf(getFree(intervalName));
 		if (valueName.equals("free mb"))

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MemoryPoolStats.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/predefined/MemoryPoolStats.java
@@ -193,7 +193,7 @@ public class MemoryPoolStats extends AbstractMemoryPoolStats implements IMemoryP
 	 * @param value the memory amount.
 	 */
 	public void setMax(long value){
-		init.setValueAsLong(value);
+		max.setValueAsLong(value);
 	}
 
 	/**


### PR DESCRIPTION
1 bug:
net.anotheria.moskito.core.predefined.MemoryPoolStats.setMax: set correct variable.

1 improvement:
net.anotheria.moskito.webui.gauges.api.GaugeAPIImpl: allow Double values.