### PR TITLE
Msk 428

### DIFF
--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
@@ -32,7 +32,7 @@ public class JMXBridgeListener<S extends IStats> implements IProducerRegistryLis
 	    	return;
 		for (IStats s : stats){
 			try{
-				MBeanUtil.getInstance().registerMBean(s, createName(producer.getProducerId(), s.getName()), false);
+				MBeanUtil.getInstance().registerMBean(s, createName(producer.getProducerId(), s.getName()));
 			} catch(Exception e){
 				log.warn("can't register "+s.getName()+" in "+producer.getProducerId()+", ignored.", e);
 			}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
@@ -63,9 +63,8 @@ public class JMXBridgeListener<S extends IStats> implements IProducerRegistryLis
 	 * @param producerId
 	 * @param statName
 	 * @return
-	 * @throws MalformedObjectNameException
 	 */
-	private String createName(String producerId, String statName) throws MalformedObjectNameException{
+	private String createName(String producerId, String statName) {
 		String appName = encodeAppName(MoskitoConfigurationHolder.getConfiguration().getApplicationName());
 		return "MoSKito."+(appName.length()>0 ? appName+ '.' :"")+"producers:type="+producerId+ '.' +statName;
 	}

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/registry/JMXBridgeListener.java
@@ -4,6 +4,7 @@ import net.anotheria.moskito.core.config.MoskitoConfigurationHolder;
 import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.util.BuiltInProducer;
+import net.anotheria.moskito.core.util.MBeanUtil;
 import net.anotheria.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,34 +28,29 @@ public class JMXBridgeListener<S extends IStats> implements IProducerRegistryLis
 		if (producer instanceof BuiltInProducer)
 			return;
 		List<S> stats = producer.getStats();
-		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
 	    if (stats == null)
 	    	return;
 		for (IStats s : stats){
 			try{
-				ObjectName name = createName(producer.getProducerId(), s.getName());
-		    	mbs.registerMBean(s, name);
-			}catch(InstanceAlreadyExistsException e){ 
-				log.warn("can't register "+s.getName()+" in "+producer.getProducerId()+", ignored InstanceAlreadyExistsException.");
-			}catch(Exception e){
+				MBeanUtil.getInstance().registerMBean(s, createName(producer.getProducerId(), s.getName()), false);
+			} catch(Exception e){
 				log.warn("can't register "+s.getName()+" in "+producer.getProducerId()+", ignored.", e);
 			}
-			
 		}
 	}
 
 	@Override
 	public void notifyProducerUnregistered(IStatsProducer<S> producer) {
 		List<S> stats = producer.getStats();
-		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
 	    if (stats == null)
 	    	return;
 		for (IStats s : stats){
 			try{
-				ObjectName name = createName(producer.getProducerId(), s.getName());
-		    	mbs.unregisterMBean(name);
-			}catch(InstanceNotFoundException e){
-				log.debug("can't unregister "+s.getName()+" in "+producer.getProducerId()+", ignored InstanceNotFoundException.");
+		    	boolean isUnregistered =
+						MBeanUtil.getInstance().unregisterMBean(createName(producer.getProducerId(), s.getName()));
+		    	if(!isUnregistered)
+					log.debug("can't unregister "+s.getName()+" in "+producer.getProducerId()+
+							", MBean with such name is not registered");
 			}catch(Exception e){
 				log.warn("can't unregister "+s.getName()+" in "+producer.getProducerId()+", ignored.", e);
 			}
@@ -69,11 +65,9 @@ public class JMXBridgeListener<S extends IStats> implements IProducerRegistryLis
 	 * @return
 	 * @throws MalformedObjectNameException
 	 */
-	private ObjectName createName(String producerId, String statName) throws MalformedObjectNameException{
+	private String createName(String producerId, String statName) throws MalformedObjectNameException{
 		String appName = encodeAppName(MoskitoConfigurationHolder.getConfiguration().getApplicationName());
-		String objectName = "MoSKito."+(appName.length()>0 ? appName+ '.' :"")+"producers:type="+producerId+ '.' +statName;
-		ObjectName objName = new ObjectName(objectName);
-		return objName;
+		return "MoSKito."+(appName.length()>0 ? appName+ '.' :"")+"producers:type="+producerId+ '.' +statName;
 	}
 
 	/**

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/ThresholdRepository.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/threshold/ThresholdRepository.java
@@ -14,6 +14,7 @@ import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.threshold.guard.DoubleBarrierPassGuard;
 import net.anotheria.moskito.core.threshold.guard.GuardedDirection;
 import net.anotheria.moskito.core.threshold.guard.LongBarrierPassGuard;
+import net.anotheria.moskito.core.util.MBeanUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,49 +93,22 @@ public class ThresholdRepository<S extends IStats> extends TieableRepository<Thr
      * removes all {@link Threshold} MBeans from platform MBeanServer.
      */
     public void cleanup() {
-        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         List<Threshold> th = getThresholds();
         for (Threshold t : th) {
             final String tName = t.getDefinition().getName();
             try {
-                unregisterMBean(mbs, createName(tName));
-            } catch (final MalformedObjectNameException e) {
-                log.warn("can't unregister " + tName + ", ignored.", e);
-            }
-        }
+            	MBeanUtil.getInstance().unregisterMBean(createName(tName));
+            } catch (MBeanRegistrationException e) {
+				log.warn("can't unregister " + tName + ", ignored.", e);
+			}
+		}
         super.cleanup();
     }
 	
-	private ObjectName createName(String name) throws MalformedObjectNameException {
+	private String createName(String name) {
         String appName = MoskitoConfigurationHolder.getConfiguration().getApplicationName();
-		String objectName = "moskito."+(appName.length()>0 ? appName+ '.' :"")+"thresholds:type="+name;
-        ObjectName objName = new ObjectName(objectName);
-        return objName;
+		return "moskito."+(appName.length()>0 ? appName+ '.' :"")+"thresholds:type="+name;
 	}
-		
-    /**
-     * Unregisters the MBean with given mbeanName from {@link MBeanServer}.
-     * 
-     * @param mbs
-     *            the {@link MBeanServer} which potentially contains the MBean to be unregistered
-     * @param mbeanName
-     *            the name of MBean to unregister.
-     * @return TRUE if such an MBean was unregistered, FLASE otherwise.
-     */
-    private boolean unregisterMBean(final MBeanServer mbs, final ObjectName mbeanName) {
-        if (mbs.isRegistered(mbeanName)) {
-            try {
-                mbs.unregisterMBean(mbeanName);
-                return true;
-
-            } catch (MBeanRegistrationException e) {
-                log.warn("unable to unregister " + mbeanName + ", ignored.", e);
-            } catch (InstanceNotFoundException e) {
-                log.warn("unable to  unregister " + mbeanName + ", ignored.", e);
-            }
-        }
-        return false;
-    }
 	
     /**
      * Creates a {@link Threshold} related to given {@link ThresholdDefinition} and registers it as
@@ -147,33 +121,19 @@ public class ThresholdRepository<S extends IStats> extends TieableRepository<Thr
      */
 	public Threshold createThreshold(ThresholdDefinition definition){
         Threshold ret = createTieable(definition);
-        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
 
         try {
 	    	// Construct the ObjectName for the MBean we will register
-            ObjectName name = createName(ret.getDefinition().getName());
-	    	
-            if (unregisterMBean(mbs, name)) {
-                log.info("there was already a MBean with name '" + name
-                        + "' registered. will be replaced now.");
-            }
-            // Register the Threshold-MBean
-            mbs.registerMBean(ret, name);
-
-        } catch (MalformedObjectNameException e) {
+            String name = createName(ret.getDefinition().getName());
+            MBeanUtil.getInstance().registerMBean(ret, name, true);
+        } catch (MalformedObjectNameException | NotCompliantMBeanException | MBeanRegistrationException e) {
 	    	log.warn("can't subscribe threshold to jmx", e);
-	    } catch (InstanceAlreadyExistsException e) {
-	    	log.warn("can't subscribe threshold to jmx", e);
-		} catch (MBeanRegistrationException e) {
-	    	log.warn("can't subscribe threshold to jmx", e);
-		} catch (NotCompliantMBeanException e) {
-	    	log.warn("can't subscribe threshold to jmx", e);
-        } catch(AccessControlException e){
+	    } catch(AccessControlException e){
 			log.warn("can't create jmx bean due to access control problems", e);
 		}
 
-
     	return ret;
+
 	}
 
 	public ExtendedThresholdStatus getExtendedWorstStatus(List<String> includedNames){

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/MBeanUtil.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/MBeanUtil.java
@@ -92,7 +92,7 @@ public class MBeanUtil {
     }
 
     /**
-     * Overloaded method with 'replace' parameter set to true.
+     * Overloaded method with 'replace' parameter set to false.
      * See:
      *  {@link MBeanUtil#registerMBean(Object, String, boolean)}
      */

--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/MBeanUtil.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/MBeanUtil.java
@@ -1,0 +1,212 @@
+package net.anotheria.moskito.core.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.*;
+import java.lang.management.ManagementFactory;
+import java.util.LinkedList;
+
+/**
+ * Utility class to register and unregister MBeans.
+ * Methods that performs registration/unregistration is
+ * synchronized on MBean server.
+ */
+public class MBeanUtil {
+
+    private static Logger log = LoggerFactory.getLogger(MBeanUtil.class);
+
+    /**
+     * MBean server instance
+     */
+    private final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    /**
+     * List with all registered by this object MBeans
+     * Required for cleanup beans
+     */
+    private LinkedList<ObjectName> beansNames = new LinkedList<>();
+
+    /**
+     * Singleton instance of util class
+     */
+    private static MBeanUtil instance = new MBeanUtil();
+
+    /**
+     * Prevents class instance creation except singleton
+     */
+    private MBeanUtil(){}
+
+    public static MBeanUtil getInstance(){
+        return instance;
+    }
+
+    /**
+     * Used to resolve MBean name duplication
+     * by adding prefix to name.
+     *
+     * Prefix format:
+     *  copy{$number}.{$originalName}
+     *  where:
+     *      $number       - bean copy number (1 for first copy)
+     *      $originalName - original bean name passed to {@link MBeanUtil#registerMBean(Object, String, boolean)} method
+     *
+     * @param name MBean name to change
+     * @return change MBean name with prefix
+     */
+    /* for testing */ static String resolveDuplicateName(String name){
+
+        if(name.matches("^copy\\d+\\..*$")){ // If true - means bean name already contain copy prefix
+
+            // Parsing copy number from prefix to increase it
+
+            // Copy number contains in the prefix end -
+            // StringBuilder is required to reverse string
+            StringBuilder copyPrefix =
+                    new StringBuilder(
+                            name.substring(0, name.indexOf('.'))
+                    );
+
+            // Collects copy number digits
+            StringBuilder copyNumber = new StringBuilder();
+
+            // Reverting copy prefix and collecting digits
+            for(Character prefixChar : copyPrefix.reverse().toString().toCharArray())
+                if(Character.isDigit(prefixChar))
+                    copyNumber.append(prefixChar);
+                else break; // loop reach end of 'copy' word. No copy number digits left
+
+            return "copy" +
+                    // Parsing copy number to integer and increase it
+                    String.valueOf(
+                            Integer.valueOf(
+                                    // Digits are collected in reverse order, reverse it again
+                                    copyNumber.reverse().toString()
+                            ) + 1
+                    ) + "." +
+                    name.substring(name.indexOf('.') + 1); // Remove old prefix
+
+        }
+        else
+            return "copy1." + name;
+
+    }
+
+    /**
+     * Overloaded method with 'replace' parameter set to true.
+     * See:
+     *  {@link MBeanUtil#registerMBean(Object, String, boolean)}
+     */
+    public String registerMBean(Object bean, String name)
+            throws MalformedObjectNameException, NotCompliantMBeanException, MBeanRegistrationException {
+        return registerMBean(bean, name, false);
+    }
+
+    /**
+     * Registers MBean in local MBean server.
+     *
+     * Method has mechanism to resolve bean name duplication
+     * depends on `replace` parameter of ths method.
+     *
+     * If true - old bean be replaced by new one.
+     * If false - prefix been added to bean name from method parameter
+     *
+     * Prefix format:
+     * copy{$number}.{$originalName}
+     * where:
+     *     $number       - bean copy number (1 for first copy)
+     *     $originalName - original bean name passed to this method
+     *
+     * @param bean MBean object
+     * @param name MBean name
+     * @param replace controls resolving of bean name duplication.
+     *                 true  - old bean be replaced by new one.
+     *                 false - prefix be added to bean name.
+     *
+     * @return name of MBean string
+     *
+     * @throws MalformedObjectNameException name from parameter is unacceptable as object name
+     * @throws NotCompliantMBeanException thrown by MBeanServer
+     * @throws MBeanRegistrationException thrown by MBeanServer
+     */
+    public String registerMBean(Object bean, String name, boolean replace)
+            throws MalformedObjectNameException, NotCompliantMBeanException, MBeanRegistrationException{
+
+        synchronized (mBeanServer) {
+
+            ObjectName newBeanName = null;
+
+            try {
+                newBeanName = new ObjectName(name);
+                beansNames.add(newBeanName); // Saving bean name for possible later cleanups
+                mBeanServer.registerMBean(bean, newBeanName);
+                return name;
+            } catch (InstanceAlreadyExistsException e) {
+
+                beansNames.remove(newBeanName); // Bean not registered, it name is not required for cleanup
+
+                if (replace) {
+                    unregisterMBean(name);
+                    return registerMBean(bean, name, true);
+                } else
+                    return registerMBean(bean, resolveDuplicateName(name));
+
+            }
+
+        }
+
+    }
+
+    /**
+     * Unregisters MBean from platform MBean server.
+     * @param name name of MBean to unregister
+     * @return true - bean unregistered
+     *         false - bean with such name not found
+     * @throws MBeanRegistrationException thrown by MBeanServer
+     */
+    public boolean unregisterMBean(String name) throws MBeanRegistrationException {
+
+        synchronized (mBeanServer) {
+
+            ObjectName toRemoveName;
+
+            try {
+                toRemoveName = new ObjectName(name);
+            } catch (MalformedObjectNameException e) {
+                return false; // bean with malformed can not be registered.
+            }
+
+            beansNames.remove(toRemoveName);
+
+            try {
+                mBeanServer.unregisterMBean(toRemoveName);
+                return true;
+            } catch (InstanceNotFoundException e) {
+                return false;
+            }
+
+        }
+
+    }
+
+    /**
+     * Unregisters all beans, that been registered by this utility object.
+     */
+    public void cleanup(){
+
+        synchronized (mBeanServer) {
+
+            for (ObjectName beanName : beansNames)
+                try {
+                    mBeanServer.unregisterMBean(beanName);
+                } catch (InstanceNotFoundException ignored) {
+                    // Bean previously been unregistered
+                } catch (MBeanRegistrationException e) {
+                    log.warn("Exception thrown while trying to clean up registered MBeans", e);
+                }
+
+        }
+
+    }
+
+
+}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/util/MBeanUtilTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/util/MBeanUtilTest.java
@@ -1,0 +1,116 @@
+package net.anotheria.moskito.core.util;
+
+import org.junit.Test;
+
+import javax.management.*;
+
+import java.lang.management.ManagementFactory;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests {@link MBeanUtil} class
+ */
+public class MBeanUtilTest {
+
+    /**
+     * Test modifying mbean name to prevent name duplication
+     * mechanism of testing class
+     */
+    @Test
+    public void testResolveDuplicateName(){
+
+        final String originalName = "SampleMBeanName:test=test";
+        String resolvedBeanName;
+
+        resolvedBeanName = MBeanUtil.resolveDuplicateName(originalName);
+        assertEquals("copy1." + originalName, resolvedBeanName);
+
+        resolvedBeanName = MBeanUtil.resolveDuplicateName(resolvedBeanName);
+        assertEquals("copy2." + originalName, resolvedBeanName);
+
+        assertEquals("copy100." + originalName, MBeanUtil.resolveDuplicateName("copy99." + originalName));
+
+    }
+
+    @Test
+    public void testRegisterAndUnregister()
+            throws MBeanRegistrationException, MalformedObjectNameException, NotCompliantMBeanException {
+
+        final String sampleBeanName = "SampleBean:test=test";
+
+        MBeanUtil.getInstance().registerMBean(sampleBean, sampleBeanName);
+
+        assertTrue(
+                MBeanUtil.getInstance().unregisterMBean(sampleBeanName) // Must return true on success remove
+        );
+
+        assertFalse(
+                // Unregistration should not be success due that bean is already removed
+                MBeanUtil.getInstance().unregisterMBean(sampleBeanName)
+        );
+
+        // Checking that MBean with test name is not registered
+        assertFalse(ManagementFactory.getPlatformMBeanServer().isRegistered(new ObjectName(sampleBeanName)));
+
+    }
+
+    @Test
+    public void testCleanup()
+            throws MBeanRegistrationException, MalformedObjectNameException, NotCompliantMBeanException {
+
+        final String sampleBeanName1 = "SampleBean:test=test,order=1";
+        final String sampleBeanName2 = "SampleBean:test=test,order=2";
+        final String sampleBeanName3 = "SampleBean:test=test,order=3";
+
+        final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+
+        MBeanUtil.getInstance().registerMBean(sampleBean, sampleBeanName1);
+        MBeanUtil.getInstance().registerMBean(sampleBean, sampleBeanName2);
+        MBeanUtil.getInstance().registerMBean(sampleBean, sampleBeanName3);
+
+        MBeanUtil.getInstance().cleanup(); // All registered beans has to be removed after cleanup() call
+
+        // Checking that MBeans with test names is not registered
+        assertFalse(mbs.isRegistered(new ObjectName(sampleBeanName1)));
+        assertFalse(mbs.isRegistered(new ObjectName(sampleBeanName2)));
+        assertFalse(mbs.isRegistered(new ObjectName(sampleBeanName3)));
+
+    }
+
+    /**
+     * Object for testing that can be used as MBean (at least in this test scope)
+     */
+    private static Object sampleBean = new DynamicMBean(){
+        @Override
+        public Object getAttribute(String attribute) throws AttributeNotFoundException, MBeanException, ReflectionException {
+            return null;
+        }
+
+        @Override
+        public void setAttribute(Attribute attribute) throws AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException {
+
+        }
+
+        @Override
+        public AttributeList getAttributes(String[] attributes) {
+            return null;
+        }
+
+        @Override
+        public AttributeList setAttributes(AttributeList attributes) {
+            return null;
+        }
+
+        @Override
+        public Object invoke(String actionName, Object[] params, String[] signature) throws MBeanException, ReflectionException {
+            return null;
+        }
+
+        @Override
+        public MBeanInfo getMBeanInfo() {
+            return new MBeanInfo("Anonymous", null, null, null, null, null);
+        }
+    };
+
+}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/util/MBeanUtilTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/util/MBeanUtilTest.java
@@ -44,7 +44,6 @@ public class MBeanUtilTest {
         final SampleBean anotherSampleBean = new SampleBean("other_test_id");
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
 
-
         // Register method should return bean name
         assertEquals(sampleBeanName,
                 MBeanUtil.getInstance().registerMBean(sampleBean, sampleBeanName)
@@ -74,6 +73,12 @@ public class MBeanUtilTest {
         // Unregistration should not be success due that bean is already removed
         assertFalse(
                 MBeanUtil.getInstance().unregisterMBean(sampleBeanName)
+        );
+
+        // Trying to unregister bean with non existing name.
+        // Method should return false
+        assertFalse(
+                MBeanUtil.getInstance().unregisterMBean("non_existing_bean")
         );
 
         // Checking that MBean with test name is not registered
@@ -107,7 +112,7 @@ public class MBeanUtilTest {
     }
 
     /**
-     * Object for testing that can be used as MBean (at least in this test scope)
+     * MBean mock for testing
      */
     private static class SampleBean implements DynamicMBean{
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/MoskitoUIFilter.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/MoskitoUIFilter.java
@@ -78,23 +78,24 @@ public class MoskitoUIFilter extends MAFFilter{
 		// Session not contains auth flag. Trying to find valid auth cookie
 		final AuthApi api = APILookupUtility.getAuthApi();
 
-		for(Cookie cookie : request.getCookies())
-			if(cookie.getName().equals(AuthConstants.AUTH_COOKIE_NAME)){
+		if(request.getCookies() != null)
+			for(Cookie cookie : request.getCookies())
+				if(cookie.getName().equals(AuthConstants.AUTH_COOKIE_NAME)){
 
-				try {
-					if(api.userExists(
-							cookie.getValue()
-					)){
-						// Valid auth cookie found. Setting auth flag in session to true
-						request.getSession().setAttribute(AuthConstants.AUTH_SESSION_ATTR_NAME, true);
-						return true;
+					try {
+						if(api.userExists(
+								cookie.getValue()
+						)){
+							// Valid auth cookie found. Setting auth flag in session to true
+							request.getSession().setAttribute(AuthConstants.AUTH_SESSION_ATTR_NAME, true);
+							return true;
+						}
+					} catch (APIException e) {
+						log.error("Failed to decrypt user authorization cookie", e);
+						return false;
 					}
-				} catch (APIException e) {
-					log.error("Failed to decrypt user authorization cookie", e);
-					return false;
-				}
 
-			}
+				}
 
 		// No auth flag in session or valid auth cookie found. Seems that user is not authorized
 		return false;

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/StartStopListener.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/StartStopListener.java
@@ -3,6 +3,7 @@ package net.anotheria.moskito.webui.util;
 import net.anotheria.moskito.core.threshold.ThresholdRepository;
 import net.anotheria.moskito.core.timing.UpdateTriggerServiceFactory;
 import net.anotheria.moskito.core.util.BuiltinUpdater;
+import net.anotheria.moskito.core.util.MBeanUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ public class StartStopListener implements ServletContextListener{
 		BuiltinUpdater.cleanup();
 		ThresholdRepository.getInstance().cleanup();
 		UpdateTriggerServiceFactory.getUpdateTriggerService().cleanup();
+		MBeanUtil.getInstance().cleanup();
 	}
 
 }


### PR DESCRIPTION
Added MBeanUtil class that can handle bean names duplication. Method registerMBean of this class can add prefix to bean name for ability to register it. Also it stores all registered beans names and has cleanup method for removing all registered beans.