### PR TITLE
Everything else/Mbeans page error on remote connection fix 

### DIFF
--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/AdditionalFunctionalityAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/AdditionalFunctionalityAPIImpl.java
@@ -164,7 +164,10 @@ public class AdditionalFunctionalityAPIImpl extends AbstractMoskitoAPIImpl imple
 				log.debug("unable to read MBean: " + e.getLocalizedMessage());
 			}
 
-			res.add(new MBeanAttributeWrapperAO(info, value.toString()));
+			res.add(new MBeanAttributeWrapperAO(
+					info,
+					value != null ? value.toString() : null
+			));
 		}
 
 		return res;

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/AdditionalFunctionalityAPIImpl.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/AdditionalFunctionalityAPIImpl.java
@@ -164,7 +164,7 @@ public class AdditionalFunctionalityAPIImpl extends AbstractMoskitoAPIImpl imple
 				log.debug("unable to read MBean: " + e.getLocalizedMessage());
 			}
 
-			res.add(new MBeanAttributeWrapperAO(info, value));
+			res.add(new MBeanAttributeWrapperAO(info, value.toString()));
 		}
 
 		return res;

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/MBeanAttributeWrapperAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/api/MBeanAttributeWrapperAO.java
@@ -13,12 +13,12 @@ public class MBeanAttributeWrapperAO implements Serializable{
     private static final long serialVersionUID = -2365810654171860016L;
 
     private final MBeanAttributeInfo attribInfo;
-    private final Object value;
+    private final String value;
 
     /**
      * Constructs an MBeanAttributeWrapperAO.
      */
-    public MBeanAttributeWrapperAO(final MBeanAttributeInfo attribInfo, final Object value) {
+    public MBeanAttributeWrapperAO(final MBeanAttributeInfo attribInfo, final String value) {
         this.attribInfo = attribInfo;
         this.value = value;
     }
@@ -57,7 +57,7 @@ public class MBeanAttributeWrapperAO implements Serializable{
     /**
      * @return the current mbean attributes value
      */
-    public Object getValue() {
+    public String getValue() {
         return value;
     }
 


### PR DESCRIPTION
Unserializable attributes in some mbeans cause crash on trying to retrieve it from remote server via rmi.
Now all mbeans attributes cast into string to ensure they can be serialized.