### PR TITLE
Removed unused variable, fix Java 9 issue

### DIFF
--- a/moskito-core/src/main/java/net/anotheria/moskito/core/util/BuiltInOSProducer.java
+++ b/moskito-core/src/main/java/net/anotheria/moskito/core/util/BuiltInOSProducer.java
@@ -67,8 +67,6 @@ public class BuiltInOSProducer extends AbstractBuiltInProducer implements IStats
 		}catch(ClassNotFoundException e){
 			log.warn("Couldn't find unix version of os class: "+clazzname+", osstats won't operate properly - "+e.getMessage());
 		}
-
-		char version=System.getProperty("java.version").charAt(2);
 		
         if (!isUnixOS) {
             log.warn("Couldn't find unix version of os class: " + clazzname


### PR DESCRIPTION
BuildInOSProducer does not work with Java 9 because the offending line expects the version number to have at leased 3 characters. Starting with Java 9 it contains only a single character '9', so this code fails with out of bounds exception.
The variable 'version' is not used at all so it can be deleted, resolving the problem described above.