### PR TITLE
fixed remotes null pointer exception bug

### DIFF
--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/WebUIConfig.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/util/WebUIConfig.java
@@ -130,6 +130,10 @@ public class WebUIConfig {
 		this.betaMode = betaMode;
 	}
 
+	private WebUIConfig(){
+		initRemotesCollections();
+	}
+
 	/**
 	 * Singleton holder class.
 	 */


### PR DESCRIPTION
If remotes not set in configuration file remotes collections is not initialized. This cause NullPointerException.