### PR TITLE
MSK-455 / MSK-456 / New Tags page

### DIFF
--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/jsp/Accumulators.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/jsp/Accumulators.jsp
@@ -68,7 +68,7 @@
                         <div class="box-right-nav dropdown">
                             <a href="#" data-target="#" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
                             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">
-                                <li><a href="" class="save_as">Save</a></li>
+                                <li><a href="" class="save_as">Screenshot</a></li>
                                 <ano:iF test="${chart.dashboardsToAdd != ''}">
                                     <li><a onclick="addChart('${requestScope.accNamesConcat}','${requestScope.dashboards}')">Add to Dashboard</a></li>
                                 </ano:iF>
@@ -102,7 +102,7 @@
                                 <div class="box-right-nav dropdown">
                                     <a href="#" data-target="#" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
                                     <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">
-                                        <li><a href="" class="save_as">Save</a></li>
+                                        <li><a href="" class="save_as">Screenshot</a></li>
                                         <ano:iF test="${chart.dashboardsToAdd != ''}">
                                             <li><a onclick="addChart('${singleGraph.name}','${requestScope.dashboards}')">Add to Dashboard</a></li>
                                         </ano:iF>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/jsp/Accumulators.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/jsp/Accumulators.jsp
@@ -8,7 +8,7 @@
 
 <section id="main">
     <ano:equal name="newAccumulatorAdded" value="true">
-        <div class="alert alert-warning alert-dismissable">
+        <div class="alert alert-success alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             Accumulator <ano:write name="newAccumulatorName"/> added!
         </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/jsp/Dashboard.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/jsp/Dashboard.jsp
@@ -8,14 +8,14 @@
 
 <section id="main">
     <ano:equal name="showHelp" value="true">
-        <div class="alert alert-warning alert-dismissable">
+        <div class="alert alert-success alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             This Dashboard is yet empty. Add some elements to it by editing <em>moskito.json</em>.<br/>For more details on MoSKito Configuration visit: <a href="https://confluence.opensource.anotheria.net/display/MSK/MoSKito-Essential+Configuration+Guide">https://confluence.opensource.anotheria.net/display/MSK/MoSKito-Essential+Configuration+Guide</a>.
         </div>
     </ano:equal>
 
     <ano:present name="infoMessage">
-        <div class="alert alert-warning alert-dismissable">
+        <div class="alert alert-success alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             ${requestScope.infoMessage}
         </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/jsp/Dashboard.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/jsp/Dashboard.jsp
@@ -55,7 +55,7 @@
                     <div class="form-group">
                         <input type="text" class="form-control" name="pName" placeholder="Name">
                     </div>
-                    <div class="form-group text-right">
+                    <div class="form-group text-center">
                         <button class="btn btn-success" type="button" onclick="submit();">Create</button>
                         <button class="btn btn-default" type="button" data-dismiss="modal">Cancel</button>
                     </div>
@@ -65,20 +65,20 @@
     </div>
 </div>
 
-<div class="modal fade" id="DeleteDashboard" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" style="display: none;">
+<div class="modal fade modal-danger" id="DeleteDashboard" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" style="display: none;">
     <div class="modal-dialog modal-sm">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
                 <h4 class="modal-title">Delete Dashboard "${requestScope.selectedDashboard}" ? </h4>
             </div>
-            <div class="modal-body">
+            <div class="modal-footer">
                 <form name="CreateDashboard" action="mskDeleteDashboard" method="GET">
                     <input type="hidden" name="remoteConnection" value="${remoteLink}"/>
                     <input type="hidden" class="form-control" name="pName" value="${requestScope.selectedDashboard}">
-                    <div class="form-group text-right">
-                        <button class="btn btn-success" type="button" onclick="submit();">Yes</button>
+                    <div class="text-center">
                         <button class="btn btn-default" type="button" data-dismiss="modal">Cancel</button>
+                        <button class="btn btn-danger" type="button" onclick="submit();">Delete</button>
                     </div>
                 </form>
             </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/jsp/widgets/ChartsWidget.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/jsp/widgets/ChartsWidget.jsp
@@ -38,7 +38,7 @@
                         <div class="box-right-nav dropdown">
                             <a href="#" data-target="#" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
                             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">
-                                <li><a href="" onclick="saveSvgAsPng(event, ${index}+countGauges())">Save</a></li>
+                                <li><a href="" onclick="saveSvgAsPng(event, ${index}+countGauges())">Screenshot</a></li>
                                 <ano:iF test="${chart.dashboardsToAdd != ''}">
                                     <li><a onclick="addChart('${chart.chartNames}','${chart.dashboardsToAdd}')">Add to Dashboard</a></li>
                                 </ano:iF>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/jsp/widgets/GaugesWidget.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/dashboards/jsp/widgets/GaugesWidget.jsp
@@ -45,7 +45,7 @@
                         <div class="box-right-nav dropdown">
                             <a href="#" data-target="#" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
                             <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">
-                                <li><a href="" onclick="saveGaugesSvgAsPng(event, ${index}, ${index})">Save</a></li>
+                                <li><a href="" onclick="saveGaugesSvgAsPng(event, ${index}, ${index})">Screenshot</a></li>
                                 <ano:iF test="${gauge.dashboardsToAdd != ''}">
                                     <li><a onclick="addGauge('${gauge.caption}', '${gauge.name}', '${gauge.dashboardsToAdd}')" >Add to Dashboard</a></li>
                                 </ano:iF>
@@ -66,7 +66,7 @@
     <div class="dashboard-line-footer text-right">
         <ul class="dashboard-line-nav-box list-unstyled">
             <li>
-                <a onclick="saveGaugesSvgAsPng(event, 0, 10000)" class="save_as"><i class="fa fa-download"></i> Save all Gauges</a>
+                <a onclick="saveGaugesSvgAsPng(event, 0, 10000)" class="save_as"><i class="fa fa-download"></i> Screenshot all Gauges</a>
             </li>
         </ul>
     </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/errors/jsp/Errors.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/errors/jsp/Errors.jsp
@@ -16,7 +16,7 @@
                 </div>
             </div>
 
-            <div id="collapse1" class="box-content accordion-body collapse in hscrollbar">
+            <div id="collapseErrors" class="box-content accordion-body collapse in hscrollbar errors-box">
                 <ano:notPresent name="catchers">
                     No catchers active or no errors have been caught yet.
                 </ano:notPresent>
@@ -51,7 +51,7 @@
             </div>
         </div>
 
-        <div id="collapse2" class="box-content accordion-body collapse in hscrollbar">
+        <div id="collapseConfig" class="box-content accordion-body collapse in errors-box">
             <p>Check the field <em>errorHandlingConfig</em> in the <mos:deepLink  href="mskConfig">configuration section</mos:deepLink > for information about currently configured error catchers. For more help on configuration options visit <a href="https://confluence.opensource.anotheria.net/display/MSK/MoSKito-Essential+Configuration+Guide">the configuration guide.</a>
             </p>
         </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/jsp/Gauges.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/jsp/Gauges.jsp
@@ -6,7 +6,7 @@
 <jsp:include page="../../shared/jsp/Header.jsp" flush="false"/>
 
 <section id="main">
-        <div class="alert alert-warning alert-dismissable">
+        <div class="alert alert-success alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             Gauges are a new feature since MoSKito 2.5.7. We are not sure, if they should become their top navigation point. If you feel that gauges should become it own top navigation point,
             <a href="mailto:moskito-users@lists.anotheria.net">tell us</a>!

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/jsp/Gauges.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/gauges/jsp/Gauges.jsp
@@ -57,7 +57,7 @@
                             <div class="box-right-nav dropdown">
                                 <a href="#" data-target="#" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
                                 <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">
-                                    <li><a href="" onclick="saveGaugesSvgAsPng(event, ${index}, ${index})">Save</a></li>
+                                    <li><a href="" onclick="saveGaugesSvgAsPng(event, ${index}, ${index})">Screenshot</a></li>
                                     <ano:iF test="${gauge.dashboardsToAdd != ''}">
                                         <li><a onclick="addGauge('${gauge.caption}', '${gauge.name}', '${gauge.dashboardsToAdd}')" >Add to Dashboard</a></li>
                                     </ano:iF>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/jsp/Journeys.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/journey/jsp/Journeys.jsp
@@ -7,7 +7,7 @@
 <jsp:include page="../../shared/jsp/Header.jsp" flush="false"/>
 <section id="main">
     <ano:notPresent name="journeysPresent">
-        <div class="alert alert-warning alert-dismissable">
+        <div class="alert alert-success alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             You have no journeys yet, you can start a journey by following the instructions below or programmatically.
         </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/jsp/Producer.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/jsp/Producer.jsp
@@ -10,12 +10,12 @@
 
 <section id="main">
     <ano:equal name="newThresholdAdded" value="true">
-        <div class="alert alert-warning alert-dismissable">
+        <div class="alert alert-success alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             Threshold <ano:write name="newThresholdName"/> added!
         </div>
         <ano:equal name="newAccumulatorAdded" value="true">
-            <div class="alert alert-warning alert-dismissable">
+            <div class="alert alert-success alert-dismissable">
                 <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                 Accumulator <ano:write name="newAccumulatorName"/> added!
             </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/jsp/Producers.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/jsp/Producers.jsp
@@ -1,6 +1,5 @@
-<%@ page language="java" contentType="text/html;charset=UTF-8"	session="true"
-%><%@ taglib uri="http://www.anotheria.net/ano-tags" prefix="ano"
-%>
+<%@ page language="java" contentType="text/html;charset=UTF-8"	session="true" %>
+<%@ taglib uri="http://www.anotheria.net/ano-tags" prefix="ano" %>
 <%@ taglib prefix="mos" uri="http://www.moskito.org/inspect/tags" %>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -44,13 +43,10 @@ Commented out for now. We may add this later as welcome message (to all layers).
     </ano:equal>
 </div>
 <div id="collapse${decorator.decoratorNameForCss}" class="box-content accordion-body collapse in">
-
-
-    <div class="table1fixed">
-        <table class="table table-striped tablesorter">
+        <table class="table table-striped tablesorter producers-table">
             <thead>
             <tr>
-                <th class="headcol">Producer Id <i class="fa fa-caret-down"></i></th>
+                <th>Producer Id <i class="fa fa-caret-down"></i></th>
                 <th>Category <i class="fa fa-caret-down"></i></th>
                 <th>Subsystem <i class="fa fa-caret-down"></i></th>
                 <ano:iterate name="decorator" property="captions" type="net.anotheria.moskito.core.decorators.value.StatCaptionBean" id="caption" indexId="ind">
@@ -60,14 +56,14 @@ Commented out for now. We may add this later as welcome message (to all layers).
                     </th>
                 </ano:iterate>
                 <th>Class</th>
-                <th class="th-actions"></th>
+                <th></th>
             </tr>
             </thead>
             <tbody>
-                    <%-- writing out values --%>
+            <%-- writing out values --%>
             <ano:iterate name="decorator" property="producers" id="producer" type="net.anotheria.moskito.webui.producers.api.ProducerAO">
             <tr>
-                <td class="headcol"><mos:deepLink  href="mskShowProducer?pProducerId=${producer.producerId}" class="tooltip-bottom" title="Show details for producer ${producer.producerId}">${producer.producerId}</mos:deepLink ></td>
+                <td><mos:deepLink  href="mskShowProducer?pProducerId=${producer.producerId}" class="tooltip-bottom" title="Show details for producer ${producer.producerId}">${producer.producerId}</mos:deepLink ></td>
                 <td><mos:deepLink  href="mskShowProducersByCategory?pCategory=${producer.category}">${producer.category}</mos:deepLink ></td>
                 <td><mos:deepLink  href="mskShowProducersBySubsystem?pSubsystem=${producer.subsystem}">${producer.subsystem}</mos:deepLink ></td>
                 <ano:iterate name="producer" property="firstStatsValues" id="value" type="net.anotheria.moskito.core.decorators.value.StatValueAO">
@@ -85,8 +81,6 @@ Commented out for now. We may add this later as welcome message (to all layers).
             </tbody>
         </table>
     </div>
-
-</div>
 </div>
 </ano:iterate>
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/jsp/Producers.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/producers/jsp/Producers.jsp
@@ -10,7 +10,7 @@
 <section id="main">
 <%--
 Commented out for now. We may add this later as welcome message (to all layers).
-<div class="alert alert-warning alert-dismissable">
+<div class="alert alert-success alert-dismissable">
     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
     <strong>Welcome</strong> to moskito WebUI. <a href="">How it work?</a>
 </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Error.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Error.jsp
@@ -1,6 +1,6 @@
-<%@ page language="java" contentType="text/html;charset=UTF-8" session="true"
-        %><%@ taglib uri="http://www.anotheria.net/ano-tags" prefix="ano"
-        %>
+<%@ page import="net.anotheria.maf.bean.ErrorBean" %>
+<%@ page language="java" contentType="text/html;charset=UTF-8" session="true" %>
+<%@ taglib uri="http://www.anotheria.net/ano-tags" prefix="ano" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <jsp:include page="Header.jsp"/>
@@ -18,7 +18,18 @@
             </div>
 
             <span class="liner"></span>
-            <ano:write name="maf.error" property="stackTrace"/>
+
+            <%
+                // Preparing stack trace array
+                String stackTraceString = ((ErrorBean) request.getAttribute("maf.error")).getStackTrace();
+                String[] stackTrace = stackTraceString.replace("[", "").replace("]", "").split(", ");
+                request.setAttribute("stackTrace", stackTrace);
+            %>
+            <div class="stack-trace-container">
+                <ano:iterate name="stackTrace" id="traceStep">
+                    <ano:write name="traceStep" /><br/>
+                </ano:iterate>
+            </div>
         </div>
 
     </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Explanations.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Explanations.jsp
@@ -8,7 +8,7 @@
 <section id="main">
     <%--
     Commented out for now. We may add this later as welcome message (to all layers).
-    <div class="alert alert-warning alert-dismissable">
+    <div class="alert alert-success alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         <strong>Welcome</strong> to moskito WebUI. <a href="">How it work?</a>
     </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Footer.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Footer.jsp
@@ -229,9 +229,11 @@
     </ano:notEqual>
 </ano:equal>
 
+<%--
 <ano:equal name="currentNaviItem" property="id" value="tags">
     <script type="text/javascript" src="../moskito/ext/jquery-tree-table/jquery.treeTable.min.js"></script>
 </ano:equal>
+--%>
 
 <ano:equal name="currentNaviItem" property="id" value="errors">
     <script type="text/javascript" src="../moskito/ext/jquery-tree-table/jquery.treeTable.min.js"></script>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Header.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Header.jsp
@@ -188,7 +188,7 @@
                     <ano:iterate name="dashboardsMenuItems" id="item">
                         <li ${requestScope.selectedDashboard == item.name ? "class=\"active\"" : ""}><mos:deepLink href="mskDashboard?dashboard=${item.urlParameter}" title="${item.name}" class="sidebar-tooltip-right">${item.name} <i class="fa fa-tachometer"></i></mos:deepLink></li>
                     </ano:iterate>
-                    <li><mos:deepLink href="#CreateDashboard" data-toggle="modal" data-target="#CreateDashboard" title="New Dashboard" class="sidebar-tooltip-right">New Dashboard <i class="fa fa-tachometer"></i></mos:deepLink></li>
+                    <li><mos:deepLink href="#CreateDashboard" data-toggle="modal" data-target="#CreateDashboard" title="New Dashboard" class="sidebar-tooltip-right">New Dashboard <i class="fa fa-plus"></i></mos:deepLink></li>
                 </ul>
             </li>
         </ano:equal>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Header.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/shared/jsp/Header.jsp
@@ -188,7 +188,7 @@
                     <ano:iterate name="dashboardsMenuItems" id="item">
                         <li ${requestScope.selectedDashboard == item.name ? "class=\"active\"" : ""}><mos:deepLink href="mskDashboard?dashboard=${item.urlParameter}" title="${item.name}" class="sidebar-tooltip-right">${item.name} <i class="fa fa-tachometer"></i></mos:deepLink></li>
                     </ano:iterate>
-                    <li><mos:deepLink href="#CreateDashboard" data-toggle="modal" data-target="#CreateDashboard" title="New Dashboard" class="sidebar-tooltip-right">New Dashboard <i class="fa fa-plus"></i></mos:deepLink></li>
+                    <li><mos:deepLink href="#CreateDashboard" data-toggle="modal" data-target="#CreateDashboard" title="New Dashboard" class="sidebar-tooltip-right">New Dashboard <i class="fa fa-plus new-dashboard-sign"></i></mos:deepLink></li>
                 </ul>
             </li>
         </ano:equal>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/tags/jsp/Tags.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/tags/jsp/Tags.jsp
@@ -14,74 +14,47 @@
     </ano:empty>
 
     <div class="content">
-        <div class="box">
-            <div class="box-content paddner">
-                <div class="pull-right">
-                    <a class="btn btn-default" data-toggle="modal" data-target="#addTagModal" href=""><i class="fa fa-plus"></i> Tag</a>
-                </div>
-            </div>
-        </div>
+        <div class="tags-wrapper">
+        <div>
+            <ano:notEmpty name="tags">
+                <ano:iterate name="tags" type="net.anotheria.moskito.webui.tags.bean.TagBean" id="tag" indexId="index">
+                    <div class="card-box">
+                        <div class="panel panel-default card-item">
+                            <div class="panel-heading card-header card-color-${tag.type.name}">
+                                <i class="fa fa-tag card-tag-icon"></i>${tag.name}
+                            </div>
+                            <div class="panel-body card-body">
+                                <p><strong>Type: </strong>${tag.type.name}</p>
+                                <p><strong>Source: </strong>${tag.source}</p>
+                            </div>
+                            <div id="tag-${index}-values" class="collapse-section collapse">
+                                <ano:iterate name="tag" property="lastValues" id="value">
+                                    <div class="card-section text-muted">${value}</div>
+                                </ano:iterate>
+                            </div>
+                            <a href="#tag-${index}-values" class="collapse-toggle collapsed" role="button" data-toggle="collapse" aria-expanded="false" aria-controls="tag-${index}-values">
+                                <div class="panel-footer card-footer">
+                                    <i class="fa fa-chevron-down"></i>
+                                </div>
+                            </a>
+                            <div class="card-footer-line card-color-${tag.type.name}"></div>
+                        </div>
+                    </div>
+                </ano:iterate>
+            </ano:notEmpty>
 
-        <ano:notEmpty name="tags">
-        <div class="box">
-            <div class="box-title">
-                <a class="accordion-toggle tooltip-bottom" title="Close/Open" data-toggle="collapse" href="#collapseTags">
-                    <i class="fa fa-caret-down"></i>
+            <div class="add-tag-box">
+                <a href="" data-toggle="modal" data-target="#addTagModal">
+                    <div class="add-tag-card">
+                        <div class="add-icon"><i class="fa fa-plus"></i></div>
+                    </div>
                 </a>
-                <h3 class="pull-left">
-                    Tags
-                </h3>
-            </div>
-            <div id="collapseTags" class="box-content accordion-body collapse in">
-                <table class="table table-striped tree">
-                    <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Type</th>
-                        <th>Source</th>
-                        <th>Last values</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                        <ano:iterate name="tags" type="net.anotheria.moskito.webui.tags.bean.TagBean" id="tag" indexId="index">
-                            <tr data-level="0">
-                                <td><i class="minus">–</i><i class="plus">+</i>${tag.name}</td>
-                                <td>${tag.type.name}</td>
-                                <td>${tag.source}</td>
-                                <td>
-                                    <ano:notEmpty name="tag" property="lastValues">
-                                        ${tag.lastValuesTruncatedString}
-                                    </ano:notEmpty>
-                                </td>
-                            </tr>
-                            <ano:notEmpty name="tag" property="lastValues">
-                                <tr data-level="1" class="treegrid-parent">
-                                    <td><b>Last tag values:</b></td>
-                                    <td colspan="3">
-                                        <table class="table table-striped">
-                                            <thead>
-                                            <tr>
-                                                <th>Value</th>
-                                            </tr>
-                                            </thead>
-                                            <tbody>
-                                            <ano:iterate name="tag" property="lastValues" id="value">
-                                                <tr>
-                                                    <td>${value}</td>
-                                                </tr>
-                                            </ano:iterate>
-                                            </tbody>
-                                        </table>
-                                    </td>
-                                </tr>
-                            </ano:notEmpty>
-                        </ano:iterate>
-                    </tbody>
-                </table>
             </div>
         </div>
-        </ano:notEmpty>
+        </div>
     </div>
+
+    <script src="../moskito/int/js/tags.js" type="text/javascript"></script>
 
     <jsp:include page="AddTagModal.jsp"/>
     <jsp:include page="../../shared/jsp/Footer.jsp" flush="false"/>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/tags/jsp/Tags.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/tags/jsp/Tags.jsp
@@ -7,7 +7,7 @@
 <jsp:include page="../../shared/jsp/Header.jsp" flush="false"/>
 <section id="main">
     <ano:empty name="tags">
-        <div class="alert alert-warning alert-dismissable">
+        <div class="alert alert-success alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             You have no tags yet, you can add new tags using MoSKito configuration or form in modal window.
         </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threads/jsp/ThreadsHistory.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threads/jsp/ThreadsHistory.jsp
@@ -7,7 +7,7 @@
 
 <section id="main">
     <ano:equal name="active" value="false">
-    <div class="alert alert-warning alert-dismissable">
+    <div class="alert alert-success alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         History is off, slide the button to switch it on.
     </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/jsp/Thresholds.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/jsp/Thresholds.jsp
@@ -7,7 +7,7 @@
 
 <section id="main">
     <ano:equal name="newThresholdAdded" value="true">
-        <div class="alert alert-warning alert-dismissable">
+        <div class="alert alert-success alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             Threshold <ano:write name="newThresholdName"/> added!
         </div>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/jsp/Thresholds.jsp
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/threshold/jsp/Thresholds.jsp
@@ -86,7 +86,7 @@
                     <ano:iterate name="alerts" type="net.anotheria.moskito.webui.threshold.api.ThresholdAlertAO" id="alert" indexId="index">
                     <tr>
                         <td>${alert.timestamp}</td>
-                        <td><a href="#">${alert.name}</a></td>
+                        <td><a class="threshold-update-link" data-id="${alert.id}" href="#">${alert.name}</a></td>
                         <td><i class="status status-${alert.oldColorCode}"></i> <i class="fa fa-long-arrow-right"></i> <i class="status status-${alert.newColorCode}"></i></td>
                         <td>${alert.oldValue} <i class="fa fa-long-arrow-right"></i> ${alert.newValue}</td>
                     </tr>

--- a/moskito-webui/src/main/resources/moskito/int/css/main.css
+++ b/moskito-webui/src/main/resources/moskito/int/css/main.css
@@ -849,8 +849,11 @@ i.heatmap-chart-icon {
 
 #main .mCSB_horizontal > .mCSB_container {
     margin-bottom: 16px;
-    margin-left: 20px;
     min-width: 100%;
+}
+
+.errors-page {
+    margin-left: 20px;
 }
 
 .status {

--- a/moskito-webui/src/main/resources/moskito/int/css/main.css
+++ b/moskito-webui/src/main/resources/moskito/int/css/main.css
@@ -852,7 +852,7 @@ i.heatmap-chart-icon {
     min-width: 100%;
 }
 
-.errors-page {
+.errors-box {
     margin-left: 20px;
 }
 
@@ -1247,6 +1247,15 @@ ul.switcher li i.chart-icon {
     margin-left: 190px;
     overflow-x: auto;
     overflow-y: auto;
+}
+
+table.producers-table > tbody > tr > td {
+    padding: 8px 0 8px 20px;
+}
+
+table.producers-table a.action-icon {
+    margin-left: 0;
+    margin-right: 0;
 }
 
 .modal-table {

--- a/moskito-webui/src/main/resources/moskito/int/css/main.css
+++ b/moskito-webui/src/main/resources/moskito/int/css/main.css
@@ -1968,3 +1968,103 @@ Heat map
     font-weight: 200;
     font-size: 14px;
 }
+
+/* TAGS PAGE SECTION */
+.tags-wrapper {
+    columns: 5;
+    column-gap: 30px;
+}
+
+.card-box {
+    margin-bottom: 30px;
+}
+
+.card-item {
+    display: inline-block;
+    width: 100%;
+    border-radius: 3px;
+    background: #fff;
+    border: 0;
+    margin-bottom: 0;
+}
+
+.card-item .card-header {
+    font-size: 18px;
+    font-weight: bold;
+    color: #fff;
+}
+
+.card-item .card-header .card-tag-icon {
+    padding-right: 10px;
+}
+
+.card-item .card-color-builtin {
+    background-color: #5bb35b;
+}
+
+.card-item .card-color-configured {
+    background-color: #c28029;
+}
+
+.card-item .card-body {
+    padding-bottom: 0;
+    font-size: 14px;
+}
+
+.card-item .card-footer {
+    text-align: center;
+    padding: 5px 10px;
+    background-color: #fcfcfc;
+}
+
+.card-item .card-footer:hover {
+    background-color: #e9e9e9;
+}
+
+.card-item .card-footer-line {
+    height: 10px;
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+}
+
+.card-item .card-section {
+    border-top: 1px solid rgb(221, 221, 221);
+    padding: 8px 12px;
+    word-wrap: break-word;
+    -ms-word-wrap: break-word;
+}
+
+.card-item .collapse-section {
+    border-top: 1px solid rgb(221, 221, 221);
+    border-bottom: 1px solid rgb(221, 221, 221);
+    min-height: 30px;
+    background-color: #f7f7f9;
+}
+
+.add-tag-box {
+    min-height: 160px;
+    width: 100%;
+    text-align: center;
+    border-radius: 3px;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+}
+
+.add-tag-card {
+    color: #428bca70;
+    border: 2px dashed #428bca70;
+}
+
+.add-tag-card:hover {
+    color: rgba(76, 158, 231, 0.83);
+    border: 2px dashed rgba(76, 158, 231, 0.83);
+}
+
+.add-tag-card .add-icon {
+    line-height: 160px;
+    font-size: 30px;
+}
+
+.tags-wrapper {
+    padding-bottom: 40px;
+}

--- a/moskito-webui/src/main/resources/moskito/int/css/main.css
+++ b/moskito-webui/src/main/resources/moskito/int/css/main.css
@@ -217,6 +217,11 @@ body.status-yellow ul.nav-sidebar.nav-status > li.active > a {
     border-left: 4px solid #e4be3c;
 }
 
+ul.nav-sidebar > li .new-dashboard-sign {
+    top: 9px;
+    font-size: 15px;
+}
+
 .status.status-green {
     background: #53d769;
 }

--- a/moskito-webui/src/main/resources/moskito/int/js/tags.js
+++ b/moskito-webui/src/main/resources/moskito/int/js/tags.js
@@ -1,0 +1,10 @@
+/**
+ * @author strel
+ */
+$(function () {
+    // Changing chevron sign orientation on collapse click
+    $('.collapse-toggle').click(function () {
+        var chevronIcon = $(this).find('i');
+        chevronIcon.toggleClass('fa-chevron-up fa-chevron-down');
+    });
+});


### PR DESCRIPTION
https://jira.opensource.anotheria.net/browse/MSK-455
- Information messages color was changed to green.
- "Save gauges / charts" renamed to "screenshot gauges / charts".
- Action buttons on Delete dashboard modal were centered.
- Changed icon for "New dashboard" on sidebar navigation to plus icon.
- Reduced free space in tables on Producers page.
- Fixed "Threshold update" link in history table on Thresholds page.

https://jira.opensource.anotheria.net/browse/MSK-456
- Stack trace is now printed line by line.

Tags page redesign:
- Tags are rendered as separate boxes with expandable list of last values.
- Box color determines tag type.