### PR TITLE
Migrate tests from JUnit 4 to JUnit 5 (parent 4.4)

### DIFF
--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/AccumulateWithSubClassesTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/AccumulateWithSubClassesTest.java
@@ -16,9 +16,9 @@ import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.core.stats.Interval;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
 import net.anotheria.moskito.core.timing.IUpdateable;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,17 +26,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author sshscp
  */
 public class AccumulateWithSubClassesTest {
 
-	@Before
+	@BeforeEach
 	public void before() {
 		ProducerRegistryFactory.getProducerRegistryInstance().cleanup();
 		AccumulatorRepository.resetForUnitTests();
@@ -100,10 +100,10 @@ public class AccumulateWithSubClassesTest {
 		new AnotherChildAccumulatorTestClass().someMethod();// nothing
 
 		//check producers presence
-		assertNotNull("Producer not found!", getProducer(ParentRegularAccumulatorClass.class));
-		assertNotNull("Producer not found!", getProducer(RegularAccumulatorTestClass.class));
-		assertNotNull("Producer not found!", getProducer(ChildAccumulatorTestClass.class));
-		assertNotNull("Producer not found!", getProducer(AnotherChildAccumulatorTestClass.class));
+		assertNotNull(getProducer(ParentRegularAccumulatorClass.class), "Producer not found!");
+		assertNotNull(getProducer(RegularAccumulatorTestClass.class), "Producer not found!");
+		assertNotNull(getProducer(ChildAccumulatorTestClass.class), "Producer not found!");
+		assertNotNull(getProducer(AnotherChildAccumulatorTestClass.class), "Producer not found!");
 
 
 		final ExpectedAccumulatorValues expected = new ExpectedAccumulatorValues();
@@ -180,13 +180,13 @@ public class AccumulateWithSubClassesTest {
 		forceIntervalUpdate("snapshot");
 		for (Map.Entry<String, Long> expectedValue : values.entries()) {
 			Accumulator accumulator = getAccumulator(expectedValue.getKey());
-			assertNotNull("Accumulator not found!", accumulator);
+			assertNotNull(accumulator, "Accumulator not found!");
 
 			List<AccumulatedValue> stats = accumulator.getValues();
-			assertTrue("Accumulated values are absent!", stats.size() > 0);
+			assertTrue(stats.size() > 0, "Accumulated values are absent!");
 
 			Long expectedCounter = expectedValue.getValue();
-			assertEquals("Expected other value!", expectedCounter.toString(), stats.get(stats.size() - 1 ).getValue());
+			assertEquals(expectedCounter.toString(), stats.get(stats.size() - 1 ).getValue(), "Expected other value!");
 		}
 	}
 
@@ -250,12 +250,12 @@ public class AccumulateWithSubClassesTest {
 		new ChildMonitoredClass().someMethod();//+1 to CHILD
 
 		//check producers presence
-		assertNotNull("Producer not found!", getProducer(ParentMonitoredClass.class));
-		assertNotNull("Producer not found!", getProducer(RegularMonitoredClass.class));
-		assertNotNull("Producer not found!", getProducer(ChildMonitoredClass.class));
+		assertNotNull(getProducer(ParentMonitoredClass.class), "Producer not found!");
+		assertNotNull(getProducer(RegularMonitoredClass.class), "Producer not found!");
+		assertNotNull(getProducer(ChildMonitoredClass.class), "Producer not found!");
 
 		//check accumulators count
-		assertEquals("Wrong accumulators count!", 3, AccumulatorRepository.getInstance().getAccumulators().size());
+		assertEquals(3, AccumulatorRepository.getInstance().getAccumulators().size(), "Wrong accumulators count!");
 
 
 		//find out generated accumulator names
@@ -358,25 +358,25 @@ public class AccumulateWithSubClassesTest {
 		new ChildWithoutAccumulator().execute2();//don't accumulate
 
 		//check producers presence
-		assertNotNull("Producer not found!", getProducer(ChildWithoutAccumulator.class));
-		assertNotNull("Producer not found!", getProducer(ParentMonitoredClassWithoutAccumulators.class));
+		assertNotNull(getProducer(ChildWithoutAccumulator.class), "Producer not found!");
+		assertNotNull(getProducer(ParentMonitoredClassWithoutAccumulators.class), "Producer not found!");
 
 		//check accumulators count
-		assertEquals("Wrong accumulators count!", 0, AccumulatorRepository.getInstance().getAccumulators().size());
+		assertEquals(0, AccumulatorRepository.getInstance().getAccumulators().size(), "Wrong accumulators count!");
 
 		new ChildWithAccumulator().execute();//goes to accumulator
 		new ChildWithAccumulator().execute2();//don't accumulate
 
-		assertNotNull("Producer not found!", getProducer(ChildWithAccumulator.class));
-		assertEquals("Wrong accumulators count!", 1, AccumulatorRepository.getInstance().getAccumulators().size());
+		assertNotNull(getProducer(ChildWithAccumulator.class), "Producer not found!");
+		assertEquals(1, AccumulatorRepository.getInstance().getAccumulators().size(), "Wrong accumulators count!");
 
 		forceIntervalUpdate("1h");
 		Accumulator accumulator = getAccumulator(findAccumulatorName(ChildWithAccumulator.class.getSimpleName()));
-		assertNotNull("Accumulator not found!", accumulator);
+		assertNotNull(accumulator, "Accumulator not found!");
 
 		List<AccumulatedValue> stats = accumulator.getValues();
-		assertTrue("Accumulated values are absent!", stats.size() > 0);
-		assertEquals("Expected other value!", "1", stats.get(stats.size() - 1 ).getValue());
+		assertTrue(stats.size() > 0, "Accumulated values are absent!");
+		assertEquals("1", stats.get(stats.size() - 1 ).getValue(), "Expected other value!");
 	}
 
 
@@ -385,7 +385,7 @@ public class AccumulateWithSubClassesTest {
 	 * from inheriting further(TestClassC) and that @DontMonitor works as expected(TestClassD)
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testMonitorOverriding() {
 		final String interval = "snapshot";
 
@@ -416,27 +416,27 @@ public class AccumulateWithSubClassesTest {
 		new TestClassD().execute();
 
 		//check accumulators count
-		assertEquals("Wrong accumulators count!", 3, AccumulatorRepository.getInstance().getAccumulators().size());
+		assertEquals(3, AccumulatorRepository.getInstance().getAccumulators().size(), "Wrong accumulators count!");
 
 		forceIntervalUpdate(interval);
 
 		for (Class clazz : new Class[]{TestClassA.class, TestClassB.class, TestClassC.class}) {
 			//check producers presence
-			assertNotNull("Producer not found!", getProducer(TestClassA.class));
+			assertNotNull(getProducer(TestClassA.class), "Producer not found!");
 
 			//check accumulator presence
 			Accumulator accumulator = getAccumulator(findAccumulatorName(clazz.getSimpleName()));
 //			accumulator.tieToStats();
-			assertNotNull("Accumulator not found!", accumulator);
+			assertNotNull(accumulator, "Accumulator not found!");
 
 			//check accumulated values
 			List<AccumulatedValue> stats = accumulator.getValues();
-			assertEquals("Expected single accumulatd value!", 1, stats.size());
-			assertEquals("Expected other value!", "1", stats.get(0).getValue());
+			assertEquals(1, stats.size(), "Expected single accumulatd value!");
+			assertEquals("1", stats.get(0).getValue(), "Expected other value!");
 		}
 
-		assertNull("Producer found!", getProducer(TestClassD.class));
-		assertNull("Accumulator found!", findAccumulatorName(TestClassD.class.getSimpleName()));
+		assertNull(getProducer(TestClassD.class), "Producer found!");
+		assertNull(findAccumulatorName(TestClassD.class.getSimpleName()), "Accumulator found!");
 
 	}
 }

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/AccumulateWithSubClassesTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/AccumulateWithSubClassesTest.java
@@ -431,7 +431,7 @@ public class AccumulateWithSubClassesTest {
 
 			//check accumulated values
 			List<AccumulatedValue> stats = accumulator.getValues();
-			assertEquals(1, stats.size(), "Expected single accumulatd value!");
+			assertEquals(1, stats.size(), "Expected single accumulated value!");
 			assertEquals("1", stats.get(0).getValue(), "Expected other value!");
 		}
 

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/AccumulatesCallTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/AccumulatesCallTest.java
@@ -6,27 +6,27 @@ import net.anotheria.moskito.aop.annotation.Monitor;
 import net.anotheria.moskito.core.accumulation.Accumulator;
 import net.anotheria.moskito.core.accumulation.AccumulatorRepository;
 import net.anotheria.moskito.core.config.MoskitoConfigurationHolder;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Roman Stetsiuk
  */
 public class AccumulatesCallTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setup() {
 		MoskitoConfigurationHolder.resetConfiguration();
 		MoskitoConfigurationHolder.getConfiguration().getBuiltinProducersConfig().disableAll();
         AccumulatorRepository.resetForUnitTests();
 	}
 
-	@AfterClass
+	@AfterAll
     public static void cleanup() {
         AccumulatorRepository.resetForUnitTests();
     }

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/AnnotatedCallTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/AnnotatedCallTest.java
@@ -4,9 +4,9 @@ import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.core.stats.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * SQL intercept test.
@@ -32,7 +32,7 @@ public class AnnotatedCallTest {
         IStatsProducer<?> producer = ProducerRegistryFactory.getProducerRegistryInstance().getProducer(AnnotatedMethod.class.getSimpleName());
         IStats doSmtgStats = producer.getStats().get(1);
         assertEquals("doSomething", doSmtgStats.getName());
-        assertEquals("Should be 10K calls", ANNOTATED_METHOD_CALLS + "", doSmtgStats.getValueByNameAsString("TR", null, TimeUnit.MICROSECONDS));
+        assertEquals(ANNOTATED_METHOD_CALLS + "", doSmtgStats.getValueByNameAsString("TR", null, TimeUnit.MICROSECONDS), "Should be 10K calls");
     }
 
     @Test
@@ -55,10 +55,10 @@ public class AnnotatedCallTest {
         // then
         IStatsProducer<?> producer = (IStatsProducer)  ProducerRegistryFactory.getProducerRegistryInstance().getProducer(AnnotatedClass.class.getSimpleName());
         IStats doSomeStats = producer.getStats().get(1);
-        assertEquals("Should be 550 calls", 550 + "", doSomeStats.getValueByNameAsString("TR", null, TimeUnit.MICROSECONDS));
+        assertEquals(550 + "", doSomeStats.getValueByNameAsString("TR", null, TimeUnit.MICROSECONDS), "Should be 550 calls");
         IStats doSome2Stats = producer.getStats().get(2);
-        assertEquals("Should be 750 calls", 750 + "", doSome2Stats.getValueByNameAsString("TR", null, TimeUnit.MICROSECONDS));
+        assertEquals(750 + "", doSome2Stats.getValueByNameAsString("TR", null, TimeUnit.MICROSECONDS), "Should be 750 calls");
         IStats doSome3Stats = producer.getStats().get(3);
-        assertEquals("Should be 1750 calls", 1750 + "", doSome3Stats.getValueByNameAsString("TR", null, TimeUnit.MICROSECONDS));
+        assertEquals(1750 + "", doSome3Stats.getValueByNameAsString("TR", null, TimeUnit.MICROSECONDS), "Should be 1750 calls");
     }
 }

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/DontMonitorAnnotationTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/DontMonitorAnnotationTest.java
@@ -3,11 +3,11 @@ package net.anotheria.moskito.aop;
 import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DontMonitorAnnotationTest {
 	@Test public void testDontMonitorMethod(){

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/MonitorWithSubClassesTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/MonitorWithSubClassesTest.java
@@ -1,23 +1,22 @@
 package net.anotheria.moskito.aop;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import net.anotheria.moskito.aop.annotation.DontMonitor;
 import net.anotheria.moskito.aop.annotation.withsubclasses.MonitorWithSubClasses;
 import net.anotheria.moskito.aop.util.MoskitoUtils;
 import net.anotheria.moskito.core.registry.IProducerRegistry;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author bvanchuhov
  */
 public class MonitorWithSubClassesTest {
 
-	@Before
+	@BeforeEach
 	public void before() {
 		ProducerRegistryFactory.getProducerRegistryInstance().cleanup();
 	}
@@ -39,7 +38,7 @@ public class MonitorWithSubClassesTest {
 		child.execute();
 
 		IProducerRegistry producerRegistry = ProducerRegistryFactory.getProducerRegistryInstance();
-		assertThat("error!", producerRegistry.getProducer(MoskitoUtils.producerName(TestClassImplementation.class.getName())), notNullValue());
+		assertNotNull(producerRegistry.getProducer(MoskitoUtils.producerName(TestClassImplementation.class.getName())), "error!");
 	}
 
 
@@ -51,7 +50,7 @@ public class MonitorWithSubClassesTest {
 		};
 		child.execute();
 		IProducerRegistry producerRegistry = ProducerRegistryFactory.getProducerRegistryInstance();
-		assertThat("error!", producerRegistry.getProducer(MoskitoUtils.producerName(child.getClass().getName())), notNullValue());
+		assertNotNull(producerRegistry.getProducer(MoskitoUtils.producerName(child.getClass().getName())), "error!");
 	}
 
 
@@ -60,7 +59,7 @@ public class MonitorWithSubClassesTest {
 		final ParentClassNotAnnotated child = new SomeOtherImpl();
 		child.execute();
 		IProducerRegistry producerRegistry = ProducerRegistryFactory.getProducerRegistryInstance();
-		assertThat("error!", producerRegistry.getProducer(MoskitoUtils.producerName(SomeOtherImpl.class.getName())), notNullValue());
+		assertNotNull(producerRegistry.getProducer(MoskitoUtils.producerName(SomeOtherImpl.class.getName())), "error!");
 	}
 
 	@Test
@@ -68,7 +67,7 @@ public class MonitorWithSubClassesTest {
 		final ParentClassNotAnnotated child = new SomeOtherImpl();
 		child.executeSomethingElse();
 		IProducerRegistry producerRegistry = ProducerRegistryFactory.getProducerRegistryInstance();
-		assertThat("error!", producerRegistry.getProducer(MoskitoUtils.producerName(SomeOtherImpl.class.getName())), nullValue());
+		assertNull(producerRegistry.getProducer(MoskitoUtils.producerName(SomeOtherImpl.class.getName())), "error!");
 	}
 
 	@Test
@@ -76,7 +75,7 @@ public class MonitorWithSubClassesTest {
 		final SupperParentClassAnnotated child = new DontMonitoredImpl();
 		child.execute();
 		IProducerRegistry producerRegistry = ProducerRegistryFactory.getProducerRegistryInstance();
-		assertThat("error!", producerRegistry.getProducer(MoskitoUtils.producerName(DontMonitoredImpl.class.getName())), nullValue());
+		assertNull(producerRegistry.getProducer(MoskitoUtils.producerName(DontMonitoredImpl.class.getName())), "error!");
 	}
 
 

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/annotation_inheritance/AnnotationInheritanceTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/annotation_inheritance/AnnotationInheritanceTest.java
@@ -8,17 +8,16 @@ import net.anotheria.moskito.core.accumulation.Accumulator;
 import net.anotheria.moskito.core.accumulation.AccumulatorRepository;
 import net.anotheria.moskito.core.registry.IProducerRegistry;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author bvanchuhov
@@ -140,7 +139,7 @@ public class AnnotationInheritanceTest {
 		TestingInterface test3 = new ThirdLevelClass();
 		test3.execute();
 		IProducerRegistry producerRegistry = ProducerRegistryFactory.getProducerRegistryInstance();
-		assertThat("Producer  found! - should not!", producerRegistry.getProducer(MoskitoUtils.producerName(ThirdLevelClass.class.getName())), nullValue());
+		assertNull(producerRegistry.getProducer(MoskitoUtils.producerName(ThirdLevelClass.class.getName())), "Producer  found! - should not!");
 	}
 
 	// checking
@@ -154,7 +153,7 @@ public class AnnotationInheritanceTest {
 		IProducerRegistry producerRegistry = ProducerRegistryFactory.getProducerRegistryInstance();
 		final String producerId = MoskitoUtils.producerName(clazz.getName());
 
-		assertThat("Producer not found!", producerRegistry.getProducer(producerId), notNullValue());
+		assertNotNull(producerRegistry.getProducer(producerId), "Producer not found!");
 
 		AccumulatorRepository<?> accumulatorRepository = AccumulatorRepository.getInstance();
 
@@ -165,7 +164,7 @@ public class AnnotationInheritanceTest {
 				accumulatorName = producerId + ".execute."+ valueName + "." + INTERVAL_VALUE;//@see AbstractMoskitoAspect#formAccumulatorNameForMethod
 				acc = accumulatorRepository.getByName(accumulatorName);
 			}
-			assertThat("Accumulator '" + accumulatorName + "' not FOUND!", acc, notNullValue());
+			assertNotNull(acc, "Accumulator '" + accumulatorName + "' not FOUND!");
 		}
 
 	}

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/monitorcalls/clazz/onclass/MonitorCallsTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/monitorcalls/clazz/onclass/MonitorCallsTest.java
@@ -2,9 +2,9 @@ package net.anotheria.moskito.aop.monitorcalls.clazz.onclass;
 
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class MonitorCallsTest {
     @Test public void testMonitorCallsMethod(){

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/monitorcalls/clazz/onmethod/MonitorCallsTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/monitorcalls/clazz/onmethod/MonitorCallsTest.java
@@ -3,15 +3,15 @@ package net.anotheria.moskito.aop.monitorcalls.clazz.onmethod;
 import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Ignore
+@Disabled
 public class MonitorCallsTest {
     @Test public void testMonitorCallsMethod(){
 

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/monitorcalls/ininterface/oninterface/MonitorCallsTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/monitorcalls/ininterface/oninterface/MonitorCallsTest.java
@@ -3,15 +3,15 @@ package net.anotheria.moskito.aop.monitorcalls.ininterface.oninterface;
 import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Ignore
+@Disabled
 public class MonitorCallsTest {
     @Test public void testMonitorCallsMethod(){
 

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/monitorcalls/ininterface/onmethod/MonitorCallsTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/monitorcalls/ininterface/onmethod/MonitorCallsTest.java
@@ -3,15 +3,15 @@ package net.anotheria.moskito.aop.monitorcalls.ininterface.onmethod;
 import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Ignore
+@Disabled
 public class MonitorCallsTest {
     @Test public void testMonitorCallsMethod(){
 

--- a/moskito-aop/src/test/java/net/anotheria/moskito/aop/tagging/TaggingAnnotationTest.java
+++ b/moskito-aop/src/test/java/net/anotheria/moskito/aop/tagging/TaggingAnnotationTest.java
@@ -1,11 +1,11 @@
 package net.anotheria.moskito.aop.tagging;
 
 import net.anotheria.moskito.core.context.MoSKitoContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author esmakula

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/accumulation/AccumulatorTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/accumulation/AccumulatorTest.java
@@ -1,9 +1,9 @@
 package net.anotheria.moskito.core.accumulation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class AccumulatorTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/accumulation/AutoAccumulationDefinitionTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/accumulation/AutoAccumulationDefinitionTest.java
@@ -1,7 +1,7 @@
 package net.anotheria.moskito.core.accumulation;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 
 public class AutoAccumulationDefinitionTest {
@@ -10,15 +10,15 @@ public class AutoAccumulationDefinitionTest {
 	public void testProducerNameTest() {
 		AutoAccumulatorDefinition def = new AutoAccumulatorDefinition();
 		def.setProducerNamePattern("(.*)ServiceImpl");
-		Assert.assertTrue(def.matches("ShopServiceImpl"));
-		Assert.assertFalse(def.matches("ShopControl"));
+		Assertions.assertTrue(def.matches("ShopServiceImpl"));
+		Assertions.assertFalse(def.matches("ShopControl"));
 	}
 
 	@Test
 	public void testStatNameTest() {
 		AutoAccumulatorDefinition def = new AutoAccumulatorDefinition();
 		def.setStatNamePattern("(.*)");
-		Assert.assertTrue(def.statNameMatches("StatName"));
+		Assertions.assertTrue(def.statNameMatches("StatName"));
 	}
 }
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/blueprint/BlueprintWithCalcTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/blueprint/BlueprintWithCalcTest.java
@@ -2,10 +2,10 @@ package net.anotheria.moskito.core.blueprint;
 
 import net.anotheria.moskito.core.predefined.RequestOrientedStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 /**
  * The clue of this test is not to test the function of calc, but to ensure that it supplies the correct data to moskito itself.
  * @author another

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/command/CommandControllerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/command/CommandControllerTest.java
@@ -2,14 +2,14 @@ package net.anotheria.moskito.core.command;
 
 import net.anotheria.moskito.core.command.CommandController;
 import net.anotheria.moskito.core.command.CommandControllerFactory;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CommandControllerTest {
 	
 	private static CommandController controller;
 
-	@BeforeClass public static void createController(){
+	@BeforeAll public static void createController(){
 		controller = CommandControllerFactory.getCommandController();
 	}
 	

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/config/dashboards/ChartConfigTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/config/dashboards/ChartConfigTest.java
@@ -1,17 +1,15 @@
 package net.anotheria.moskito.core.config.dashboards;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ChartConfigTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void buildCaptionAccumulatorsEmpty() throws Exception {
         ChartConfig chartConfig = new ChartConfig();
-        String caption = chartConfig.buildCaption();
+        assertThrows(NullPointerException.class, chartConfig::buildCaption);
     }
 
     @Test
@@ -19,7 +17,7 @@ public class ChartConfigTest {
         ChartConfig chartConfig = new ChartConfig();
         chartConfig.setAccumulators(new String[] {"fair", "is", "foul", "and", "foul", "is", "fair"});
         String caption = chartConfig.buildCaption();
-        assertThat(caption, is("and fair fair foul foul is is"));
+        assertEquals("and fair fair foul foul is is", caption);
     }
 
 }

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/config/dashboards/DashboardConfigTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/config/dashboards/DashboardConfigTest.java
@@ -1,11 +1,11 @@
 package net.anotheria.moskito.core.config.dashboards;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DashboardConfigTest {
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/context/MoSKitoContextTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/context/MoSKitoContextTest.java
@@ -1,11 +1,11 @@
 package net.anotheria.moskito.core.context;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class MoSKitoContextTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/counter/CounterStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/counter/CounterStatsTest.java
@@ -3,9 +3,9 @@ package net.anotheria.moskito.core.counter;
 import net.anotheria.moskito.core.dynamic.OnDemandStatsProducer;
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class CounterStatsTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/counter/MaleFemaleStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/counter/MaleFemaleStatsTest.java
@@ -1,9 +1,9 @@
 package net.anotheria.moskito.core.counter;
 
 import net.anotheria.moskito.core.dynamic.OnDemandStatsProducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This test demonstrates how to use the MaleFemaleStats objects.

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/CreateDecoratorsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/CreateDecoratorsTest.java
@@ -8,7 +8,7 @@ import net.anotheria.moskito.core.decorators.predefined.MemoryStatsDecorator;
 import net.anotheria.moskito.core.decorators.predefined.ServiceStatsDecorator;
 import net.anotheria.moskito.core.decorators.util.SessionCountDecorator;
 import net.anotheria.moskito.core.decorators.util.StorageStatsDecorator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test simply tests whether decorators can be created ensuring that the amount of elements in the explanation, short_explanation and captions arrays are the same.

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/DecoratorRegistryTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/DecoratorRegistryTest.java
@@ -16,16 +16,16 @@ import net.anotheria.moskito.core.predefined.ServiceStats;
 import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.util.storage.StorageStats;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DecoratorRegistryTest {
 	
 	private static IDecoratorRegistry registry;
-	@BeforeClass public static void init(){
+	@BeforeAll public static void init(){
 		registry = DecoratorRegistryFactory.getDecoratorRegistry();
 	}
 	
@@ -41,8 +41,8 @@ public class DecoratorRegistryTest {
 	
 	private void testResolution(Class<? extends IStats> statsPattern, Class<? extends IDecorator> decoratorPattern) throws Exception{
 		IDecorator resolvedDecorator = registry.getDecorator(statsPattern);
-		assertNotNull("Resolved decorator was null! ", resolvedDecorator);
-		assertEquals("Resolved decorator is not of expected type", decoratorPattern, resolvedDecorator.getClass());
+		assertNotNull(resolvedDecorator, "Resolved decorator was null! ");
+		assertEquals(decoratorPattern, resolvedDecorator.getClass(), "Resolved decorator is not of expected type");
 		//this is not necessarily a registry test, but it ensures that the returned type actually can basically handle pattern type.
 		assertNotNull(resolvedDecorator.getValues(statsPattern.newInstance(), null, TimeUnit.MILLISECONDS));
 	}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/value/DoubleValueAOTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/decorators/value/DoubleValueAOTest.java
@@ -1,10 +1,9 @@
 package net.anotheria.moskito.core.decorators.value;
 
 import java.util.Locale;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DoubleValueAOTest {
 
@@ -155,7 +154,7 @@ public class DoubleValueAOTest {
     private void assertFormatting(double doubleValue, String expected) {
         DoubleValueAO doubleValueAO = new DoubleValueAO("name", doubleValue);
         String returnValue = doubleValueAO.getValue();
-        assertThat(returnValue, is(expected));
+        assertEquals(expected, returnValue);
     }
 
 }

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/EntryCountLimitedOnDemandStatsProducerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/EntryCountLimitedOnDemandStatsProducerTest.java
@@ -1,11 +1,11 @@
 package net.anotheria.moskito.core.dynamic;
 
 import net.anotheria.moskito.core.predefined.ServiceStatsFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class EntryCountLimitedOnDemandStatsProducerTest {
@@ -20,7 +20,7 @@ public class EntryCountLimitedOnDemandStatsProducerTest {
 	
 	private void testWithLimit(EntryCountLimitedOnDemandStatsProducer p, int limit) throws Exception{
 		p.setLimit(limit);
-		assertEquals("expected previously set limit", limit, p.getLimit());
+		assertEquals(limit, p.getLimit(), "expected previously set limit");
 		for (int i=0; i<limit; i++)
 			p.getStats(String.valueOf(i));
 		//now limit should be reached.

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducerListenerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducerListenerTest.java
@@ -11,15 +11,15 @@ import net.anotheria.moskito.core.predefined.ServiceStats;
 import net.anotheria.moskito.core.predefined.ServiceStatsFactory;
 import net.anotheria.moskito.core.registry.IProducerRegistry;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OnDemandStatsProducerListenerTest {
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/OnDemandStatsProducerTest.java
@@ -5,15 +5,15 @@ import net.anotheria.moskito.core.predefined.ServiceStats;
 import net.anotheria.moskito.core.predefined.ServiceStatsFactory;
 import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.util.IdCodeGenerator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class OnDemandStatsProducerTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/ProxyUtilsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/dynamic/ProxyUtilsTest.java
@@ -1,13 +1,8 @@
 package net.anotheria.moskito.core.dynamic;
 
-import org.hamcrest.Matcher;
-import org.hamcrest.core.Is;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsSame.sameInstance;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by dheid on 28.05.16.
@@ -35,10 +30,10 @@ public class ProxyUtilsTest {
         };
         Class[] mergedInterfaces = ProxyUtils.mergeInterfaces(interf, additionalClasses);
 
-        assertThat(mergedInterfaces, arrayWithSize(3));
-        assertThat(mergedInterfaces[0] == TestInterfaceA.class, is(true));
-        assertThat(mergedInterfaces[1] == TestInterfaceB.class, is(true));
-        assertThat(mergedInterfaces[2] == TestInterfaceC.class, is(true));
+        assertEquals(3, mergedInterfaces.length);
+        assertSame(TestInterfaceA.class, mergedInterfaces[0]);
+        assertSame(TestInterfaceB.class, mergedInterfaces[1]);
+        assertSame(TestInterfaceC.class, mergedInterfaces[2]);
     }
 
 }

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/entrypoint/PastMeasurementChainNodeTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/entrypoint/PastMeasurementChainNodeTest.java
@@ -1,9 +1,9 @@
 package net.anotheria.moskito.core.entrypoint;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test for PastMeasurementChainNode.

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/errorhandling/BuiltInErrorProducerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/errorhandling/BuiltInErrorProducerTest.java
@@ -8,14 +8,14 @@ import net.anotheria.moskito.core.context.MoSKitoContext;
 import net.anotheria.moskito.core.dynamic.ProxyUtils;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
 import net.anotheria.moskito.core.timing.IUpdateable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for builtin error producer.
@@ -25,7 +25,7 @@ import static org.junit.Assert.fail;
  */
 public class BuiltInErrorProducerTest {
 
-	@Before
+	@BeforeEach
 	public void resetCachedConfig(){
 		BuiltInErrorProducer.getInstance().testingReset();
 	}
@@ -180,7 +180,7 @@ public class BuiltInErrorProducerTest {
 
 	}
 
-	@Before public void before(){
+	@BeforeEach public void before(){
 		BuiltInErrorProducer.getInstance().testingReset();
 		MoskitoConfigurationHolder.resetConfiguration();
 		MoSKitoContext.get().reset();

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/errorhandling/ErrorCatcherTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/errorhandling/ErrorCatcherTest.java
@@ -7,16 +7,16 @@ import net.anotheria.moskito.core.context.MoSKitoContext;
 import net.anotheria.moskito.core.errorhandling.BuiltInErrorProducer;
 import net.anotheria.moskito.core.errorhandling.BuiltinErrorCatcher;
 import net.anotheria.moskito.core.errorhandling.ErrorCatcher;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class ErrorCatcherTest {
 
-	@Before
+	@BeforeEach
 	public void before(){
 		BuiltInErrorProducer.getInstance().testingReset();
 		MoskitoConfigurationHolder.resetConfiguration();

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/exceptions/ExceptionPassingTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/exceptions/ExceptionPassingTest.java
@@ -3,8 +3,8 @@ package net.anotheria.moskito.core.exceptions;
 import net.anotheria.moskito.core.dynamic.MoskitoInvokationProxy;
 import net.anotheria.moskito.core.predefined.ServiceStatsCallHandler;
 import net.anotheria.moskito.core.predefined.ServiceStatsFactory;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExceptionPassingTest {
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/journey/JourneyManagerFactoryTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/journey/JourneyManagerFactoryTest.java
@@ -1,8 +1,8 @@
 package net.anotheria.moskito.core.journey;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class JourneyManagerFactoryTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/journey/JourneyManagerImplTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/journey/JourneyManagerImplTest.java
@@ -1,10 +1,10 @@
 package net.anotheria.moskito.core.journey;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class JourneyManagerImplTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/logging/StatsLoggerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/logging/StatsLoggerTest.java
@@ -44,7 +44,7 @@ public class StatsLoggerTest {
 		String message = output.getMessage();
 		//System.out.println(message);
 		
-		assertEquals(message.indexOf("TESTINTERVAL"), -1, "Word TESTINTERVAL shouldn't be present in output");//The word TESTINTERVAL shouldn't occure there
+		assertEquals(-1, message.indexOf("TESTINTERVAL"), "Word TESTINTERVAL shouldn't be present in output");//The word TESTINTERVAL shouldn't occure there
 		assertTrue(message.indexOf("default")>-1, "Word default should be present in output");//The word default should occure there
 		assertTrue(message.indexOf("first")>-1);
 		assertTrue(message.indexOf("second")>-1);

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/logging/StatsLoggerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/logging/StatsLoggerTest.java
@@ -5,10 +5,10 @@ import net.anotheria.moskito.core.predefined.ServiceStats;
 import net.anotheria.moskito.core.predefined.ServiceStatsFactory;
 import net.anotheria.moskito.core.stats.Interval;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StatsLoggerTest {
 	
@@ -44,8 +44,8 @@ public class StatsLoggerTest {
 		String message = output.getMessage();
 		//System.out.println(message);
 		
-		assertEquals("Word TESTINTERVAL shouldn't be present in output", message.indexOf("TESTINTERVAL"), -1);//The word TESTINTERVAL shouldn't occure there
-		assertTrue("Word default should be present in output", message.indexOf("default")>-1);//The word default should occure there
+		assertEquals(message.indexOf("TESTINTERVAL"), -1, "Word TESTINTERVAL shouldn't be present in output");//The word TESTINTERVAL shouldn't occure there
+		assertTrue(message.indexOf("default")>-1, "Word default should be present in output");//The word default should occure there
 		assertTrue(message.indexOf("first")>-1);
 		assertTrue(message.indexOf("second")>-1);
 		assertTrue(message.indexOf("TT: 123")>-1);

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/CacheStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/CacheStatsTest.java
@@ -1,13 +1,13 @@
 package net.anotheria.moskito.core.predefined;
 
 import net.anotheria.moskito.core.stats.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class CacheStatsTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/GCStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/GCStatsTest.java
@@ -1,13 +1,13 @@
 package net.anotheria.moskito.core.predefined;
 
 import net.anotheria.moskito.core.stats.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Garbage collector Stats Test

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/GlobalRequestProcessorStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/GlobalRequestProcessorStatsTest.java
@@ -1,13 +1,13 @@
 package net.anotheria.moskito.core.predefined;
 
 import net.anotheria.moskito.core.stats.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Global Request Processor Stats Test

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/QueueStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/QueueStatsTest.java
@@ -2,11 +2,11 @@ package net.anotheria.moskito.core.predefined;
 
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 public class QueueStatsTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/RequestOrientedStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/RequestOrientedStatsTest.java
@@ -3,13 +3,13 @@ package net.anotheria.moskito.core.predefined;
 import net.anotheria.moskito.core.producers.CallExecution;
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RequestOrientedStatsTest {
 	@Test public void testCalculation(){
@@ -120,7 +120,7 @@ public class RequestOrientedStatsTest {
 
 		assertEquals(1, stats.getTotalRequests());
 		//we add some 5 milliseconds on top, but ensure that total duration is below 60ms, which the test as such took.
-		assertTrue("Expected total time be below 55ms but it was "+stats.getTotalTime(),1000L*1000*55>stats.getTotalTime());
+		assertTrue(1000L*1000*55>stats.getTotalTime(), "Expected total time be below 55ms but it was "+stats.getTotalTime());
 	}
 
 	@Test public void testDoublePause()  throws InterruptedException {
@@ -139,7 +139,7 @@ public class RequestOrientedStatsTest {
 		assertEquals(1, stats.getTotalRequests());
 		//we add some 5 milliseconds on top, but ensure that total duration is below 60ms, which the test as such took.
 
-		assertTrue("Expected total time be below 50ms but it was "+stats.getTotalTime(), 1000L * 1000 * 55 > stats.getTotalTime());
+		assertTrue(1000L * 1000 * 55 > stats.getTotalTime(), "Expected total time be below 50ms but it was "+stats.getTotalTime());
 	}
 
 	@Test public void testDoubleResume()  throws InterruptedException {
@@ -157,7 +157,7 @@ public class RequestOrientedStatsTest {
 		assertEquals(1, stats.getTotalRequests());
 		//we add some 5 milliseconds on top, but ensure that total duration is below 60ms, which the test as such took.
 		//System.out.println(stats.getTotalTime());
-		assertTrue("Expected total time be below 50ms but it was "+stats.getTotalTime(), 1000L * 1000 * 55 > stats.getTotalTime());
+		assertTrue(1000L * 1000 * 55 > stats.getTotalTime(), "Expected total time be below 50ms but it was "+stats.getTotalTime());
 	}
 
 }

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ServiceStatsCallHandlerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ServiceStatsCallHandlerTest.java
@@ -5,12 +5,12 @@ import net.anotheria.moskito.core.calltrace.RunningTraceContainer;
 import net.anotheria.moskito.core.dynamic.IOnDemandCallHandler;
 import net.anotheria.moskito.core.dynamic.MoskitoInvokationProxy;
 import net.anotheria.moskito.core.producers.IStatsProducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ServiceStatsCallHandlerTest {
 	
@@ -28,12 +28,12 @@ public class ServiceStatsCallHandlerTest {
 		for (int i=0; i<10; i++)
 			service.increase();
 		
-		assertEquals("count doesn't match", 10, impl.getCount());
+		assertEquals(10, impl.getCount(), "count doesn't match");
 		
 		IStatsProducer p = proxy.getProducer();
 		ServiceStats stats = (ServiceStats)p.getStats().get(0);
 		
-		assertEquals("monitored count doesn't match", 10, stats.getTotalRequests());
+		assertEquals(10, stats.getTotalRequests(), "monitored count doesn't match");
 		
 		
 	}
@@ -62,13 +62,13 @@ public class ServiceStatsCallHandlerTest {
 			fail("Exception expected");
 		}catch(Exception e){}
 		
-		assertEquals("count doesn't match", 10, impl.getCount());
+		assertEquals(10, impl.getCount(), "count doesn't match");
 		
 		IStatsProducer p = proxy.getProducer();
 		ServiceStats stats = (ServiceStats)p.getStats().get(0);
 		
-		assertEquals("monitored count doesn't match", 12, stats.getTotalRequests());
-		assertEquals("monitored count doesn't match", 2, stats.getErrors());
+		assertEquals(12, stats.getTotalRequests(), "monitored count doesn't match");
+		assertEquals(2, stats.getErrors(), "monitored count doesn't match");
 		
 		
 	}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ServiceStatsParallelTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ServiceStatsParallelTest.java
@@ -2,11 +2,11 @@ package net.anotheria.moskito.core.predefined;
 
 import net.anotheria.moskito.core.predefined.Constants;
 import net.anotheria.moskito.core.predefined.ServiceStats;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ServiceStatsParallelTest {
 	private ServiceStats stats = new ServiceStats("test", Constants.getDefaultIntervals());
@@ -43,7 +43,7 @@ public class ServiceStatsParallelTest {
 		//*/
 		
 		assertEquals(counter.get(), stats.getTotalRequests());
-		assertEquals("Number of threads must be equal to max concurrent requests", numberOfThreads, stats.getMaxCurrentRequests());
+		assertEquals(numberOfThreads, stats.getMaxCurrentRequests(), "Number of threads must be equal to max concurrent requests");
 		
 	}
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ServiceStatsParallelTestOld.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ServiceStatsParallelTestOld.java
@@ -2,10 +2,10 @@ package net.anotheria.moskito.core.predefined;
 
 import net.anotheria.moskito.core.predefined.Constants;
 import net.anotheria.moskito.core.predefined.ServiceStats;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicLong;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ServiceStatsParallelTestOld {
 	private ServiceStats stats = new ServiceStats("test", Constants.getDefaultIntervals());

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ServiceStatsSimpleTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ServiceStatsSimpleTest.java
@@ -2,8 +2,8 @@ package net.anotheria.moskito.core.predefined;
 
 import net.anotheria.moskito.core.predefined.Constants;
 import net.anotheria.moskito.core.predefined.ServiceStats;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ServiceStatsSimpleTest {
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ThreadCountStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ThreadCountStatsTest.java
@@ -1,10 +1,10 @@
 package net.anotheria.moskito.core.predefined;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class ThreadCountStatsTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ThreadStateStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/predefined/ThreadStateStatsTest.java
@@ -2,9 +2,9 @@ package net.anotheria.moskito.core.predefined;
 
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class ThreadStateStatsTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/registry/ProducerReferenceTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/registry/ProducerReferenceTest.java
@@ -1,8 +1,8 @@
 package net.anotheria.moskito.core.registry;
 
 import net.anotheria.moskito.core.producers.IStatsProducer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -13,9 +13,9 @@ import java.util.List;
  */
 public class ProducerReferenceTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIllegalArgumentException() {
-        new ProducerReference(null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ProducerReference(null));
     }
 
     @Test
@@ -25,8 +25,8 @@ public class ProducerReferenceTest {
         ProducerReference ref_1 = new ProducerReference(producer);
         ProducerReference ref_2 = new ProducerReference(producer);
 
-        Assert.assertNotSame("References should have different identities", ref_1, ref_2);
-        Assert.assertEquals("References should be equal", ref_1, ref_2);
+        Assertions.assertNotSame(ref_1, ref_2, "References should have different identities");
+        Assertions.assertEquals(ref_1, ref_2, "References should be equal");
     }
 
     /**

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/registry/ProducerRegistryTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/registry/ProducerRegistryTest.java
@@ -2,19 +2,19 @@ package net.anotheria.moskito.core.registry;
 
 import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.producers.IStatsProducer;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ProducerRegistryTest {
 	
-	@BeforeClass public static void init(){
+	@BeforeAll public static void init(){
 		System.setProperty("JUNITTEST", "true");
 	}
 	
@@ -100,7 +100,7 @@ public class ProducerRegistryTest {
 		
 	}
 	
-	@Before public void reset(){
+	@BeforeEach public void reset(){
 		ProducerRegistryFactory.reset();
 	}
 }

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/registry/RegistryMemoryLeakTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/registry/RegistryMemoryLeakTest.java
@@ -1,11 +1,11 @@
 package net.anotheria.moskito.core.registry;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.ref.WeakReference;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * This tests doesn't test moskito itself, but tests its underlying technology (weak ref usage for registry). 
  * In case it fails (due do jdk changes or something) its an indicator that something is wrong with moskito registry reference maintaining.

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/registry/filters/FiltersTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/registry/filters/FiltersTest.java
@@ -2,20 +2,20 @@ package net.anotheria.moskito.core.registry.filters;
 
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.IProducerFilter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class FiltersTest {
 
 	private List<IStatsProducer> dummies;
 
-	@Before public void setup(){
+	@BeforeEach public void setup(){
 		dummies = new ArrayList<IStatsProducer>();
 		dummies.add(new DummyProducer("1", "category1", "subsystem1"));
 		dummies.add(new DummyProducer("2", "category1", "subsystem2"));

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/snapshot/SnapshotCreatorTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/snapshot/SnapshotCreatorTest.java
@@ -4,9 +4,9 @@ import net.anotheria.moskito.core.dynamic.OnDemandStatsProducer;
 import net.anotheria.moskito.core.dynamic.OnDemandStatsProducerException;
 import net.anotheria.moskito.core.predefined.ServiceStats;
 import net.anotheria.moskito.core.predefined.ServiceStatsFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SnapshotCreatorTest extends BaseSnapshotTest{
 	@Test public void testCreateSnapshot() throws OnDemandStatsProducerException {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/snapshot/SnapshotRepositoryTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/snapshot/SnapshotRepositoryTest.java
@@ -3,15 +3,15 @@ package net.anotheria.moskito.core.snapshot;
 import net.anotheria.moskito.core.dynamic.OnDemandStatsProducer;
 import net.anotheria.moskito.core.predefined.ServiceStats;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class SnapshotRepositoryTest extends BaseSnapshotTest{
 
-	@Before
+	@BeforeEach
 	public void setup(){
 		System.setProperty("JUNITTEST", "true");
 		ProducerRegistryFactory.reset();

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/DiffLongValueHolderTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/DiffLongValueHolderTest.java
@@ -1,9 +1,9 @@
 package net.anotheria.moskito.core.stats.impl;
 
 import net.anotheria.moskito.core.stats.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test that checks DiffLongValueHolder feature: counting diff instead of absolute value.

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/IntValueHolderTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/IntValueHolderTest.java
@@ -1,7 +1,7 @@
 package net.anotheria.moskito.core.stats.impl;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IntValueHolderTest {
 	@Test public void testArythmetics(){

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/IntervalImplTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/IntervalImplTest.java
@@ -2,10 +2,10 @@ package net.anotheria.moskito.core.stats.impl;
 
 import net.anotheria.moskito.core.stats.IIntervalListener;
 import net.anotheria.moskito.core.stats.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class IntervalImplTest {
 	@Test public void testListener(){

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/IntervalNameParserTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/IntervalNameParserTest.java
@@ -35,9 +35,9 @@
 package net.anotheria.moskito.core.stats.impl;
 
 import net.anotheria.moskito.core.stats.UnknownIntervalLengthException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This is a test of IntervalNameParser.  

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/LongValueHolderTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/LongValueHolderTest.java
@@ -1,7 +1,7 @@
 package net.anotheria.moskito.core.stats.impl;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class LongValueHolderTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/NegativeCurrentRequestsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/stats/impl/NegativeCurrentRequestsTest.java
@@ -2,8 +2,8 @@ package net.anotheria.moskito.core.stats.impl;
 
 import net.anotheria.moskito.core.predefined.ServiceStats;
 import net.anotheria.moskito.core.stats.Interval;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class NegativeCurrentRequestsTest {
@@ -18,8 +18,8 @@ public class NegativeCurrentRequestsTest {
 		stats.notifyRequestFinished();
 		stats.notifyRequestFinished();
 		
-		assertEquals("Current requests should be 0", 0, stats.getCurrentRequests());
-		assertEquals("Current requests should be 0", 0, stats.getCurrentRequests("1m"));
+		assertEquals(0, stats.getCurrentRequests(), "Current requests should be 0");
+		assertEquals(0, stats.getCurrentRequests("1m"), "Current requests should be 0");
 		
 
 		stats.addRequest();
@@ -29,8 +29,8 @@ public class NegativeCurrentRequestsTest {
 		//stats.
 		((IntervalImpl)interval).update();
 		
-		assertEquals("Current requests should be 3", 3, stats.getCurrentRequests());
-		assertEquals("Current requests should be 3", 3, stats.getCurrentRequests("1m"));
+		assertEquals(3, stats.getCurrentRequests(), "Current requests should be 3");
+		assertEquals(3, stats.getCurrentRequests("1m"), "Current requests should be 3");
 
 		stats.notifyRequestFinished();
 		stats.notifyRequestFinished();
@@ -38,7 +38,7 @@ public class NegativeCurrentRequestsTest {
 
 		((IntervalImpl)interval).update();
 
-		assertEquals("Current requests should be 0", 0, stats.getCurrentRequests());
-		//TODO -> this is yet broken !assertEquals("Current requests should be 0", 0, stats.getCurrentRequests("1m"));
+		assertEquals(0, stats.getCurrentRequests(), "Current requests should be 0");
+		//TODO -> this is yet broken !assertEquals(0, stats.getCurrentRequests("1m"), "Current requests should be 0");
 	}
 }

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/FindThresholdTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/FindThresholdTest.java
@@ -6,21 +6,21 @@ import net.anotheria.moskito.core.registry.IProducerRegistryAPI;
 import net.anotheria.moskito.core.registry.ProducerRegistryAPIFactory;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class FindThresholdTest {
-	@BeforeClass public static void setup(){
+	@BeforeAll public static void setup(){
 		System.setProperty("JUNITTEST", "false");
 		ProducerRegistryFactory.reset();
 	}
 	
-	@AfterClass public static void teardown(){
+	@AfterAll public static void teardown(){
 		System.setProperty("JUNITTEST", "true");
 		ProducerRegistryFactory.reset();
 	}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/GuardsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/GuardsTest.java
@@ -3,10 +3,10 @@ package net.anotheria.moskito.core.threshold;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
 import net.anotheria.moskito.core.threshold.guard.GuardedDirection;
 import net.anotheria.moskito.core.threshold.guard.LongBarrierPassGuard;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class GuardsTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/ThresholdConfigTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/ThresholdConfigTest.java
@@ -8,15 +8,15 @@ import net.anotheria.moskito.core.config.thresholds.ThresholdsConfig;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Test for the configuration of the
@@ -25,20 +25,20 @@ import static org.junit.Assert.assertNull;
  * @since 25.10.12 10:53
  */
 public class ThresholdConfigTest {
-	@BeforeClass
+	@BeforeAll
 	public static void setup(){
 		System.setProperty("JUNITTEST", "false");
 		ProducerRegistryFactory.reset();
 
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void teardown(){
 		System.setProperty("JUNITTEST", "true");
 		ProducerRegistryFactory.reset();
 	}
 
-	@Before
+	@BeforeEach
 	public void prepareConfiguration(){
 		MoskitoConfiguration config = MoskitoConfigurationHolder.getConfiguration();
 		ThresholdsConfig tc = new ThresholdsConfig();
@@ -107,7 +107,7 @@ public class ThresholdConfigTest {
 
 	}
 
-	@After
+	@AfterEach
 	public void resetConfiguration(){
 		MoskitoConfigurationHolder.resetConfiguration();
 	}

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/ThresholdStatusTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/ThresholdStatusTest.java
@@ -1,9 +1,9 @@
 package net.anotheria.moskito.core.threshold;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThresholdStatusTest {
 	@Test public void testoverrule(){

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/alerts/AlertDispatcherTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/threshold/alerts/AlertDispatcherTest.java
@@ -6,10 +6,10 @@ import net.anotheria.moskito.core.config.thresholds.NotificationProviderConfig;
 import net.anotheria.moskito.core.threshold.Threshold;
 import net.anotheria.moskito.core.threshold.ThresholdDefinition;
 import net.anotheria.moskito.core.threshold.ThresholdStatus;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class AlertDispatcherTest {
@@ -56,7 +56,7 @@ public class AlertDispatcherTest {
 
 	}
 
-	@After public void cleanup(){
+	@AfterEach public void cleanup(){
 		MoskitoConfigurationHolder.resetConfiguration();
 	}
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/tracer/ShrinkingStrategyTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/tracer/ShrinkingStrategyTest.java
@@ -4,12 +4,12 @@ import net.anotheria.moskito.core.config.MoskitoConfiguration;
 import net.anotheria.moskito.core.config.MoskitoConfigurationHolder;
 import net.anotheria.moskito.core.config.tracing.ShrinkingStrategy;
 import net.anotheria.moskito.core.config.tracing.TracingConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class ShrinkingStrategyTest {

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/tracer/TracerTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/tracer/TracerTest.java
@@ -4,8 +4,8 @@ import net.anotheria.moskito.core.config.MoskitoConfiguration;
 import net.anotheria.moskito.core.config.MoskitoConfigurationHolder;
 import net.anotheria.moskito.core.config.tracing.ShrinkingStrategy;
 import net.anotheria.moskito.core.config.tracing.TracingConfiguration;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TracerTest {
 	@Test
@@ -62,7 +62,7 @@ public class TracerTest {
 
 		assertEquals(max, tracer.getEntryCount());
 		assertEquals(String.valueOf(tolerated - max + 1), tracer.getTraces().get(0).getCall());
-		assertEquals("Ensure we have same last element, ", overflow.getCall(), tracer.getTraces().get(tracer.getTraces().size() - 1).getCall());
+		assertEquals(overflow.getCall(), tracer.getTraces().get(tracer.getTraces().size() - 1).getCall(), "Ensure we have same last element, ");
 
 
 

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/util/MBeanUtilTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/util/MBeanUtilTest.java
@@ -1,12 +1,12 @@
 package net.anotheria.moskito.core.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.management.*;
 
 import java.lang.management.ManagementFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@link MBeanUtil} class

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/util/annotation/AnnotationUtilsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/util/annotation/AnnotationUtilsTest.java
@@ -1,6 +1,6 @@
 package net.anotheria.moskito.core.util.annotation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
@@ -11,10 +11,9 @@ import java.lang.annotation.Target;
 
 import static net.anotheria.moskito.core.util.annotation.AnnotationUtils.findAnnotation;
 import static net.anotheria.moskito.core.util.annotation.AnnotationUtils.findTypeAnnotation;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bvanchuhov
@@ -115,9 +114,9 @@ public class AnnotationUtilsTest {
 		checkFoundAnnotation(MyTestClass.class, ParentTypeAnnotation.class);
 		checkFoundAnnotation(MyTestClass.class, SuperParentTypeAnnotation.class);
 
-		assertThat("Found absent annotation!", findTypeAnnotation(MyTestClass.class, Deprecated.class), nullValue());
-		assertThat("Found absent annotation!", findTypeAnnotation(TypeAnnotation.class, Deprecated.class), nullValue());
-		assertThat("Found absent annotation!", findTypeAnnotation(SimpleMarker.class, Retention.class), nullValue());
+		assertNull(findTypeAnnotation(MyTestClass.class, Deprecated.class), "Found absent annotation!");
+		assertNull(findTypeAnnotation(TypeAnnotation.class, Deprecated.class), "Found absent annotation!");
+		assertNull(findTypeAnnotation(SimpleMarker.class, Retention.class), "Found absent annotation!");
 
 		checkFoundAnnotation(ChildConfig.class, Config.class);
 		checkFoundAnnotation(MyTestClass.class, Config.class);
@@ -125,7 +124,7 @@ public class AnnotationUtilsTest {
 
 	private static <A extends Annotation> void checkFoundAnnotation(final Class<?> type, final Class<A> targetAnnotationClass) {
     	A annotation = findTypeAnnotation(type, targetAnnotationClass);
-    	assertThat("Annotation not found!", annotation, notNullValue());
+    	assertNotNull(annotation, "Annotation not found!");
     	assertTrue(annotation.annotationType() == targetAnnotationClass);
 	}
 }

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/util/session/SessionCountStatsTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/util/session/SessionCountStatsTest.java
@@ -3,10 +3,10 @@ package net.anotheria.moskito.core.util.session;
 
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SessionCountStatsTest {
     @Test

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/util/storage/StorageTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/util/storage/StorageTest.java
@@ -1,18 +1,18 @@
 package net.anotheria.moskito.core.util.storage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StorageTest {
 	@Test public void testStats(){
 		Storage<String,Integer> storage = Storage.createHashMapStorage("test");
 		
-		assertTrue("Storage must be empty at start", storage.isEmpty());
+		assertTrue(storage.isEmpty(), "Storage must be empty at start");
 		
 		storage.put("a", 1);
 		storage.put("a", 2);

--- a/moskito-core/src/test/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtilityTest.java
+++ b/moskito-core/src/test/java/net/anotheria/moskito/core/util/threadhistory/ThreadHistoryUtilityTest.java
@@ -1,23 +1,23 @@
 package net.anotheria.moskito.core.util.threadhistory;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-@Ignore
+@Disabled
 public class ThreadHistoryUtilityTest {
 	
 	private static final int THREADCOUNT = 5;
 
-	@BeforeClass public static void setUpdate(){
+	@BeforeAll public static void setUpdate(){
 		ThreadHistoryUtility.INSTANCE.setUpdateInterval(1000L);
 	}
 
 	//set this test to ignore, since its not very stable.
-	@Ignore
+	@Disabled
 	@Test public void testOffMode() throws InterruptedException{
 		ThreadHistoryUtility.INSTANCE.deactivate();
 		for (int i=0; i<THREADCOUNT; i++){

--- a/moskito-extensions/moskito-additional-producers/src/test/java/net/anotheria/moskito/extensions/producers/RollingOnDemandStatsProducerTest.java
+++ b/moskito-extensions/moskito-additional-producers/src/test/java/net/anotheria/moskito/extensions/producers/RollingOnDemandStatsProducerTest.java
@@ -3,11 +3,11 @@ package net.anotheria.moskito.extensions.producers;
 import net.anotheria.moskito.core.predefined.ServiceStats;
 import net.anotheria.moskito.core.predefined.ServiceStatsFactory;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class RollingOnDemandStatsProducerTest {
@@ -30,8 +30,8 @@ public class RollingOnDemandStatsProducerTest {
 				found5 = true;
 		}
 
-		assertTrue("We should have found the stats number 5", found5);
-		assertFalse("We should have found the stats number 5", found0);
+		assertTrue(found5, "We should have found the stats number 5");
+		assertFalse(found0, "We should have found the stats number 5");
 
 		long sizeBeforeAdd = IntervalRegistry.getInstance().getInterval("1m").getPrimaryListenerCount();
 		producer.getStats("StatsThatWeDidn'tHadYet");

--- a/moskito-extensions/moskito-mongodb/src/main/test/java/net/anotheria/moskito/extension/mongodb/MongodbMonitorTest.java
+++ b/moskito-extensions/moskito-mongodb/src/main/test/java/net/anotheria/moskito/extension/mongodb/MongodbMonitorTest.java
@@ -2,17 +2,17 @@ package net.anotheria.moskito.extension.mongodb;
 
 import net.anotheria.moskito.core.dynamic.OnDemandStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test for mongodb monitor
  */
 public class MongodbMonitorTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setup(){
         /* to disable builtin producers */
         System.setProperty("JUNITTEST", Boolean.TRUE.toString());

--- a/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/core/stats/impl/SkipFirstDiffLongValueHolderTest.java
+++ b/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/core/stats/impl/SkipFirstDiffLongValueHolderTest.java
@@ -6,10 +6,10 @@ import net.anotheria.moskito.core.stats.Interval;
 import net.anotheria.moskito.core.stats.StatValue;
 import net.anotheria.moskito.core.stats.StatValueTypes;
 import net.anotheria.moskito.core.stats.TypeAwareStatValue;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author dzhmud
@@ -88,7 +88,7 @@ public class SkipFirstDiffLongValueHolderTest {
     }
 
     @Test
-    @Ignore("DiffLong and childs does not work correctly with 'default' interval.")
+    @Disabled("DiffLong and childs does not work correctly with 'default' interval.")
     public void testDefaultInterval() {
         final StatValue statValue = createStatValue();
         final Interval interval = IntervalRegistry.getInstance().getInterval("default", 0);

--- a/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/PluginTypeRegistryTest.java
+++ b/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/PluginTypeRegistryTest.java
@@ -1,8 +1,8 @@
 package net.anotheria.moskito.extensions.monitoring;
 
 import net.anotheria.moskito.extensions.monitoring.stats.ApacheStats;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Some test for PluginTypeRegistry.

--- a/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/metric/ApacheMetricsTest.java
+++ b/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/metric/ApacheMetricsTest.java
@@ -1,11 +1,11 @@
 package net.anotheria.moskito.extensions.monitoring.metric;
 
 import net.anotheria.moskito.extensions.monitoring.metrics.ApacheMetrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Some tests for ApacheMetrics class.

--- a/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/metric/GenericMetricsTest.java
+++ b/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/metric/GenericMetricsTest.java
@@ -2,11 +2,11 @@ package net.anotheria.moskito.extensions.monitoring.metric;
 
 import net.anotheria.moskito.core.stats.StatValueTypes;
 import net.anotheria.moskito.extensions.monitoring.metrics.GenericMetrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test for {@link GenericMetrics}

--- a/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/metric/NginxMetricsTest.java
+++ b/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/metric/NginxMetricsTest.java
@@ -1,11 +1,11 @@
 package net.anotheria.moskito.extensions.monitoring.metric;
 
 import net.anotheria.moskito.extensions.monitoring.metrics.NginxMetrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Some tests for NginxMetrics class.

--- a/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/parser/ApacheStatusParserTest.java
+++ b/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/parser/ApacheStatusParserTest.java
@@ -1,10 +1,10 @@
 package net.anotheria.moskito.extensions.monitoring.parser;
 
 import net.anotheria.moskito.extensions.monitoring.metrics.ApacheMetrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for ApacheStatusParser class.

--- a/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/parser/NginxStubStatusParserTest.java
+++ b/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/parser/NginxStubStatusParserTest.java
@@ -1,14 +1,14 @@
 package net.anotheria.moskito.extensions.monitoring.parser;
 
 import net.anotheria.moskito.extensions.monitoring.metrics.NginxMetrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Generic NginxStubStatusParser test.

--- a/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/parser/StatusDataTest.java
+++ b/moskito-extensions/moskito-monitoring-plugin/src/test/java/net/anotheria/moskito/extensions/monitoring/parser/StatusDataTest.java
@@ -3,13 +3,13 @@ package net.anotheria.moskito.extensions.monitoring.parser;
 import net.anotheria.moskito.core.stats.StatValue;
 import net.anotheria.moskito.core.stats.StatValueTypes;
 import net.anotheria.moskito.extensions.monitoring.metrics.IGenericMetrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for StatusData bean.

--- a/moskito-extensions/moskito-notification-providers/src/test/java/net/anotheria/moskito/extensions/notificationproviders/ManualTestEmailProviderTest.java
+++ b/moskito-extensions/moskito-notification-providers/src/test/java/net/anotheria/moskito/extensions/notificationproviders/ManualTestEmailProviderTest.java
@@ -8,8 +8,8 @@ import net.anotheria.moskito.core.threshold.ThresholdDefinition;
 import net.anotheria.moskito.core.threshold.ThresholdStatus;
 import net.anotheria.moskito.core.threshold.alerts.AlertDispatcher;
 import net.anotheria.moskito.core.threshold.alerts.ThresholdAlert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test is used for manual testing of the email notificationprovider.
@@ -20,7 +20,7 @@ import org.junit.Test;
  */
 public class ManualTestEmailProviderTest {
 
-    @Ignore
+    @Disabled
 	@Test public void generateMailConfigAndTriggerMail() throws Exception{
 		//prepare config
 		MoskitoConfiguration config = new MoskitoConfiguration();

--- a/moskito-extensions/moskito-notification-providers/src/test/java/notificationtemplate/MailTemplateTest.java
+++ b/moskito-extensions/moskito-notification-providers/src/test/java/notificationtemplate/MailTemplateTest.java
@@ -5,13 +5,13 @@ import net.anotheria.moskito.core.threshold.ThresholdDefinition;
 import net.anotheria.moskito.core.threshold.ThresholdStatus;
 import net.anotheria.moskito.core.threshold.alerts.ThresholdAlert;
 import net.anotheria.moskito.extensions.notificationtemplate.ThresholdAlertTemplate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit for {@link net.anotheria.moskito.extensions.notificationtemplate.MailTemplate}.
  */
 public class MailTemplateTest {
-	//@Ignore
+	//@Disabled
 	@Test
 	public void testAlertThresholdTemplate() throws Exception {
 		ThresholdDefinition td = new ThresholdDefinition();

--- a/moskito-integration/moskito-ehcache/src/test/java/net/anotheria/moskito/integration/ehcache/MonitoredEhcacheTest.java
+++ b/moskito-integration/moskito-ehcache/src/test/java/net/anotheria/moskito/integration/ehcache/MonitoredEhcacheTest.java
@@ -8,15 +8,15 @@ import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 import net.sf.ehcache.Statistics;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests for {@link net.anotheria.moskito.integration.ehcache.MonitoredEhcache}.
@@ -25,13 +25,13 @@ import static org.junit.Assert.assertNotNull;
  */
 public class MonitoredEhcacheTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setup(){
         /* to disable builtin producers */
         System.setProperty("JUNITTEST", Boolean.TRUE.toString());
     }
 
-    @Ignore //TODO this test is very unstable due to sleep, it should be fixed
+    @Disabled //TODO this test is very unstable due to sleep, it should be fixed
     @Test
     public void test() throws OnDemandStatsProducerException, InterruptedException {
         Ehcache cache = CacheManager.getInstance().getCache("test-cache");

--- a/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/ConnectionCallAspectTest.java
+++ b/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/ConnectionCallAspectTest.java
@@ -1,14 +1,14 @@
 package net.anotheria.moskito.sql.callingAspect;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class ConnectionCallAspectTest {
 
-	@Before
+	@BeforeEach
 	public void init(){
 		System.setProperty("JUNITTEST", String.valueOf(true));
 	}

--- a/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/InterceptTest.java
+++ b/moskito-integration/moskito-sql/src/test/java/net/anotheria/moskito/sql/callingAspect/InterceptTest.java
@@ -1,17 +1,17 @@
 package net.anotheria.moskito.sql.callingAspect;
 
 import net.anotheria.moskito.sql.util.TestDBUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.sql.Connection;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * SQL intercept test.
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
  *         Date: 11/29/11
  *         Time: 2:22 PM
  */
-@Ignore
+@Disabled
 public class InterceptTest {
 
     private static final String LINESEP = System.getProperty("line.separator");
@@ -33,7 +33,7 @@ public class InterceptTest {
 
     private Connection connection;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         connection = TestDBUtil.getConnection();
         TestDBUtil.createTable(connection);
@@ -51,12 +51,12 @@ public class InterceptTest {
         System.out.println("Created " + valueDAO.getMatcherValue(connection, matcherValue.getId()));
         String sql = outputStream.toString();
         String expected = INTERCEPTED_OUTPUT;
-        assertEquals("Should have logged query", expected, sql);
+        assertEquals(expected, sql, "Should have logged query");
     }
 
 
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         TestDBUtil.dropTable(connection);
         connection.close();

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/MoskitoFilterTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/MoskitoFilterTest.java
@@ -1,10 +1,10 @@
 package net.anotheria.moskito.web;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.FilterConfig;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MoskitoFilterTest {
 	@Test public void testProducerId(){

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/MoskitoHttpServletTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/MoskitoHttpServletTest.java
@@ -10,29 +10,26 @@ import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.IProducerRegistryAPI;
 import net.anotheria.moskito.core.registry.ProducerRegistryAPIFactory;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-@RunWith(MockitoJUnitRunner.class)
 public class MoskitoHttpServletTest {
 	
 	private static final long GETS = 5, POSTS = 10, HEADS = 2, PUTS = 6, LM = 4, TRACES = 13, OPTIONS = 2, DELETES = 20;
 
-	@BeforeClass public static void setProperty(){
+	@BeforeAll public static void setProperty(){
 		System.setProperty("JUNITTEST", "true");
 	}
 	
-	@Before public void reset(){
+	@BeforeEach public void reset(){
 		ProducerRegistryFactory.reset();
 	}
 	
@@ -78,7 +75,7 @@ public class MoskitoHttpServletTest {
 		List<IStats> stats = producer.getStats();
 		for (IStats s : stats){
 			//System.out.println(s);
-			assertEquals("Mismatch in "+s.getName(), ((ServletStats)s).getTotalRequests(), controlMap.get(s.getName()).longValue());
+			assertEquals(((ServletStats)s).getTotalRequests(), controlMap.get(s.getName()).longValue(), "Mismatch in "+s.getName());
 		}
 	}
 
@@ -161,7 +158,7 @@ public class MoskitoHttpServletTest {
 		List<IStats> stats = producer.getStats();
 		for (IStats s : stats){
 			//System.out.println(s);
-			assertEquals("Mismatch in "+s.getName(), ((ServletStats)s).getServletExceptions(), controlMap.get(s.getName()).longValue());
+			assertEquals(((ServletStats)s).getServletExceptions(), controlMap.get(s.getName()).longValue(), "Mismatch in "+s.getName());
 		}
 	}
 }

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/MoskitoHttpServletTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/MoskitoHttpServletTest.java
@@ -75,7 +75,7 @@ public class MoskitoHttpServletTest {
 		List<IStats> stats = producer.getStats();
 		for (IStats s : stats){
 			//System.out.println(s);
-			assertEquals(((ServletStats)s).getTotalRequests(), controlMap.get(s.getName()).longValue(), "Mismatch in "+s.getName());
+			assertEquals(controlMap.get(s.getName()).longValue(), ((ServletStats)s).getTotalRequests(), "Mismatch in "+s.getName());
 		}
 	}
 
@@ -158,7 +158,7 @@ public class MoskitoHttpServletTest {
 		List<IStats> stats = producer.getStats();
 		for (IStats s : stats){
 			//System.out.println(s);
-			assertEquals(((ServletStats)s).getServletExceptions(), controlMap.get(s.getName()).longValue(), "Mismatch in "+s.getName());
+			assertEquals(controlMap.get(s.getName()).longValue(), ((ServletStats)s).getServletExceptions(), "Mismatch in "+s.getName());
 		}
 	}
 }

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/filters/DomainFilterTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/filters/DomainFilterTest.java
@@ -5,8 +5,8 @@ import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.registry.ProducerRegistryAPIFactory;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.web.TestingUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -15,7 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +28,7 @@ public class DomainFilterTest {
 	
 	public static final String[] DOMAINS = {"www.example.com", "www.example.com", "www.example.com", "www.google.com", "www.example.com"};
 	
-	@Before public void cleanup(){
+	@BeforeEach public void cleanup(){
 		ProducerRegistryFactory.getProducerRegistryInstance().cleanup();
 	}
 	
@@ -55,7 +55,7 @@ public class DomainFilterTest {
 		
 		List<IStats> stats = new ProducerRegistryAPIFactory().createProducerRegistryAPI().getProducer(filter.getProducerId()).getStats();
 		
-		assertEquals("expect 3 stat entries ", 3, stats.size());
+		assertEquals(3, stats.size(), "expect 3 stat entries ");
 		assertEquals(DOMAINS.length, ((FilterStats)stats.get(0)).getTotalRequests());
 
 		assertEquals(4, ((FilterStats)stats.get(1)).getTotalRequests());

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/filters/JSTalkBackFilterTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/filters/JSTalkBackFilterTest.java
@@ -6,8 +6,8 @@ import net.anotheria.moskito.core.registry.ProducerRegistryAPIFactory;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.web.TestingUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -35,7 +35,7 @@ public class JSTalkBackFilterTest {
 		System.setProperty("JUNITTEST", "true");
 	}
 
-	@Before
+	@BeforeEach
 	public void cleanup() {
 		ProducerRegistryFactory.getProducerRegistryInstance().cleanup();
 	}
@@ -82,7 +82,7 @@ public class JSTalkBackFilterTest {
 
 		List<IStats> stats = new ProducerRegistryAPIFactory().createProducerRegistryAPI().getProducer("JSTalkBackFilter2").getStats();
 
-		assertEquals("Expected predefined producer and producer with name: " + url, 2, stats.size());
+		assertEquals(2, stats.size(), "Expected predefined producer and producer with name: " + url);
 		assertEquals("cumulated", stats.get(0).getName());
 
 		final PageInBrowserStats pageInBrowserStats = (PageInBrowserStats) stats.get(1);

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/filters/MethodFilterTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/filters/MethodFilterTest.java
@@ -7,8 +7,8 @@ import net.anotheria.moskito.core.registry.IProducerRegistryAPI;
 import net.anotheria.moskito.core.registry.ProducerRegistryAPIFactory;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.web.TestingUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -16,7 +16,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +28,7 @@ public class MethodFilterTest {
 	
 	public static final String[] METHODS = {"GET", "GET", "GET", "POST", "GET"};
 	
-	@Before public void cleanup(){
+	@BeforeEach public void cleanup(){
 		ProducerRegistryFactory.getProducerRegistryInstance().cleanup();
 	}
 	
@@ -46,7 +46,7 @@ public class MethodFilterTest {
 		IStatsProducer producer = api.getProducer(filter.getProducerId());
 		List<IStats> stats = producer.getStats();
 		
-		assertEquals("expect 2 stat entries ", 2, stats.size());
+		assertEquals(2, stats.size(), "expect 2 stat entries ");
 		assertEquals(METHODS.length, ((FilterStats)stats.get(0)).getTotalRequests());
 		assertEquals(METHODS.length, ((FilterStats)stats.get(1)).getTotalRequests());
 
@@ -77,7 +77,7 @@ public class MethodFilterTest {
 		IStatsProducer producer = api.getProducer(filter.getProducerId());
 		List<IStats> stats = producer.getStats();
 		
-		assertEquals("expect 3 stat entries ", 3, stats.size());
+		assertEquals(3, stats.size(), "expect 3 stat entries ");
 		assertEquals(METHODS.length, ((FilterStats)stats.get(0)).getTotalRequests());
 
 		assertEquals(4, ((FilterStats)stats.get(1)).getTotalRequests());

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/filters/UserAgentFilterTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/filters/UserAgentFilterTest.java
@@ -5,8 +5,8 @@ import net.anotheria.moskito.core.producers.IStats;
 import net.anotheria.moskito.core.registry.ProducerRegistryAPIFactory;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.web.TestingUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -15,7 +15,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ public class UserAgentFilterTest {
 	
 	public static final String[] AGENTS = {"chrome", "chrome", "firefox", "firefox", "chrome"};
 	
-	@Before public void cleanup(){
+	@BeforeEach public void cleanup(){
 		ProducerRegistryFactory.getProducerRegistryInstance().cleanup();
 	}
 	
@@ -51,7 +51,7 @@ public class UserAgentFilterTest {
 		
 		List<IStats> stats = new ProducerRegistryAPIFactory().createProducerRegistryAPI().getProducer(filter.getProducerId()).getStats();
 		
-		assertEquals("expect 3 stat entries ", 3, stats.size());
+		assertEquals(3, stats.size(), "expect 3 stat entries ");
 		assertEquals(AGENTS.length, ((FilterStats)stats.get(0)).getTotalRequests());
 
 		assertEquals(3, ((FilterStats)stats.get(1)).getTotalRequests());

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/session/SessionCountProducerIntervalTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/session/SessionCountProducerIntervalTest.java
@@ -2,12 +2,12 @@ package net.anotheria.moskito.web.session;
 
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
 import net.anotheria.moskito.core.util.session.SessionCountStats;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpSessionEvent;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/moskito-web/src/test/java/net/anotheria/moskito/web/session/SessionCountProducerTest.java
+++ b/moskito-web/src/test/java/net/anotheria/moskito/web/session/SessionCountProducerTest.java
@@ -1,13 +1,13 @@
 package net.anotheria.moskito.web.session;
 
 import net.anotheria.moskito.core.util.session.SessionCountStats;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpSessionEvent;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class SessionCountProducerTest {

--- a/moskito-webui/pom.xml
+++ b/moskito-webui/pom.xml
@@ -154,11 +154,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <!--<scope>test</scope> -->

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/accumulators/action/TestAccumulatorNormalization.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/accumulators/action/TestAccumulatorNormalization.java
@@ -2,19 +2,19 @@ package net.anotheria.moskito.webui.accumulators.action;
 
 import net.anotheria.moskito.webui.accumulators.bean.AccumulatedValuesBean;
 import net.anotheria.moskito.webui.shared.api.MoskitoAPIInitializer;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestAccumulatorNormalization {
 
-	@BeforeClass public static void initialize(){
+	@BeforeAll public static void initialize(){
 		MoskitoAPIInitializer.initialize();
 	}
 
@@ -36,10 +36,10 @@ public class TestAccumulatorNormalization {
 	
 	private void checkForFloatSimilarity(String f1, String f2, String ... ff){
 		float pattern = Float.parseFloat(f1);
-		assertTrue("expected similarity in "+pattern+", "+f2, Math.abs(pattern-Float.parseFloat(f2))<0.1);
+		assertTrue(Math.abs(pattern-Float.parseFloat(f2))<0.1, "expected similarity in "+pattern+", "+f2);
 		if (ff!=null){
 			for (String s : ff){
-				assertTrue("expected similarity in "+pattern+", "+Float.parseFloat(s), Math.abs(pattern-Float.parseFloat(s))<0.1);
+				assertTrue(Math.abs(pattern-Float.parseFloat(s))<0.1, "expected similarity in "+pattern+", "+Float.parseFloat(s));
 			}
 		}
 	}

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPITest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/accumulators/api/AccumulatorAPITest.java
@@ -7,18 +7,18 @@ import net.anotheria.moskito.core.config.MoskitoConfigurationHolder;
 import net.anotheria.moskito.core.predefined.Constants;
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.stats.impl.IntervalRegistry;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 public class AccumulatorAPITest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
 		MoskitoConfigurationHolder.resetConfiguration();
 		MoskitoConfigurationHolder.getConfiguration().getBuiltinProducersConfig().disableAll();
@@ -42,7 +42,7 @@ public class AccumulatorAPITest {
 
     }
 
-    @Ignore
+    @Disabled
 	@Test
     public void testGetAccumulatorGraphData() throws Exception {
         final AccumulatorDefinitionAO accumulatorDef1 = createAccumulator("testAccumulator1");
@@ -52,18 +52,18 @@ public class AccumulatorAPITest {
         AccumulatorAPI api = APIFinder.findAPI(AccumulatorAPI.class);
         final AccumulatedSingleGraphAO accumulatorGraphAO1 = api.getAccumulatorGraphData(accumulatorDef1.getId());
         assertNotNull(accumulatorGraphAO1);
-        assertEquals("Should be equals", "testAccumulator1", accumulatorGraphAO1.getName());
-        assertEquals("Should be equals", "testColor1", accumulatorGraphAO1.getColor());
+        assertEquals("testAccumulator1", accumulatorGraphAO1.getName(), "Should be equals");
+        assertEquals("testColor1", accumulatorGraphAO1.getColor(), "Should be equals");
 
         final AccumulatedSingleGraphAO accumulatorGraphAO2 = api.getAccumulatorGraphData(accumulatorDef2.getId());
         assertNotNull(accumulatorGraphAO2);
-        assertEquals("Should be equals", "testAccumulator2", accumulatorGraphAO2.getName());
-        assertEquals("Should be equals", "testColor2", accumulatorGraphAO2.getColor());
+        assertEquals("testAccumulator2", accumulatorGraphAO2.getName(), "Should be equals");
+        assertEquals("testColor2", accumulatorGraphAO2.getColor(), "Should be equals");
 
         final AccumulatedSingleGraphAO accumulatorGraphAO3 = api.getAccumulatorGraphData(accumulatorDef3.getId());
         assertNotNull(accumulatorGraphAO3);
-        assertEquals("Should be equals", "testAccumulator3", accumulatorGraphAO3.getName());
-        assertNull("Should be null", accumulatorGraphAO3.getColor());
+        assertEquals("testAccumulator3", accumulatorGraphAO3.getName(), "Should be equals");
+        assertNull(accumulatorGraphAO3.getColor(), "Should be null");
 
     }
 

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/accumulators/api/GetAccumulatorGraphDataTest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/accumulators/api/GetAccumulatorGraphDataTest.java
@@ -19,21 +19,21 @@ import net.anotheria.moskito.webui.shared.api.TieablePO;
 import net.anotheria.moskito.webui.threshold.api.ThresholdAPI;
 import net.anotheria.moskito.webui.threshold.api.ThresholdAPIFactory;
 import net.anotheria.moskito.webui.threshold.api.ThresholdPO;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GetAccumulatorGraphDataTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void startUpTest() {
         System.setProperty("JUNITTEST", "true");
         APIFinder.setMockingEnabled(true);
@@ -41,14 +41,14 @@ public class GetAccumulatorGraphDataTest {
         APIFinder.cleanUp();
     }
 
-    @AfterClass
+    @AfterAll
     public static void shutDownTests() {
         System.clearProperty("JUNITTEST");
         APIFinder.cleanUp();
         MoskitoConfigurationHolder.resetConfiguration();
     }
 
-    @Before
+    @BeforeEach
     public void startUp() {
         APIFinder.addAPIFactory(AccumulatorAPI.class, new AccumulatorAPIFactory());
         APIFinder.addAPIFactory(ThresholdAPI.class, new ThresholdAPIFactory());
@@ -60,7 +60,7 @@ public class GetAccumulatorGraphDataTest {
         ThresholdRepository.resetForUnitTests();
     }
 
-    @After
+    @AfterEach
     public void shutDown() {
         APIFinder.cleanUp();
         ProducerRegistryAPIFactory.resetForUnitTest();
@@ -81,7 +81,7 @@ public class GetAccumulatorGraphDataTest {
         assertEquals(aRepository.getAccumulators().size(), 0);
         createFakeAccumulators(new String[]{"a1", "a2", "a3", "a4", "a5", "a6", "a7"});
         assertEquals(aRepository.getAccumulators().size(), 7);
-        assertEquals("Expected 6: "+registry.getProducers(), 6, registry.getProducers().size());
+        assertEquals(6, registry.getProducers().size(), "Expected 6: "+registry.getProducers());
 
 
         ThresholdRepository tRepository = ThresholdRepository.getInstance();

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/accumulators/api/GetAccumulatorGraphDataTest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/accumulators/api/GetAccumulatorGraphDataTest.java
@@ -80,7 +80,7 @@ public class GetAccumulatorGraphDataTest {
 
         assertEquals(aRepository.getAccumulators().size(), 0);
         createFakeAccumulators(new String[]{"a1", "a2", "a3", "a4", "a5", "a6", "a7"});
-        assertEquals(aRepository.getAccumulators().size(), 7);
+        assertEquals(7, aRepository.getAccumulators().size());
         assertEquals(6, registry.getProducers().size(), "Expected 6: "+registry.getProducers());
 
 

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/dashboards/DashboardsAPITest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/dashboards/DashboardsAPITest.java
@@ -8,19 +8,19 @@ import net.anotheria.moskito.core.config.dashboards.ChartConfig;
 import net.anotheria.moskito.core.config.dashboards.DashboardConfig;
 import net.anotheria.moskito.core.config.dashboards.DashboardsConfig;
 import net.anotheria.moskito.webui.dashboards.api.DashboardAPIImpl;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 
 public class DashboardsAPITest {
 
 	private DashboardAPIImpl api = new DashboardAPIImpl();
 
-	@BeforeClass public static void setup(){
+	@BeforeAll public static void setup(){
 		APIFinder.setMockingEnabled(true);
 	}
 
@@ -58,7 +58,7 @@ public class DashboardsAPITest {
 		}
 	}
 
-	@Before public void prepareMoskitoConfig(){
+	@BeforeEach public void prepareMoskitoConfig(){
 		MoskitoConfiguration myConfig = new MoskitoConfiguration();
 
 		DashboardConfig myFirstDashboard = new DashboardConfig();

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/dashboards/getDashboardTest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/dashboards/getDashboardTest.java
@@ -29,23 +29,23 @@ import net.anotheria.moskito.webui.producers.api.ProducerAPI;
 import net.anotheria.moskito.webui.producers.api.ProducerAPIFactory;
 import net.anotheria.moskito.webui.threshold.api.ThresholdAPI;
 import net.anotheria.moskito.webui.threshold.api.ThresholdAPIFactory;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class getDashboardTest {
@@ -53,13 +53,13 @@ public class getDashboardTest {
     private DashboardAPI api;
     private DashboardConfig testDashboard;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         System.setProperty("JUNITTEST", "true");
         APIFinder.setMockingEnabled(true);
     }
 
-    @AfterClass
+    @AfterAll
     public static void shutDownTests() {
         System.clearProperty("JUNITTEST");
         APIFinder.cleanUp();
@@ -68,7 +68,7 @@ public class getDashboardTest {
         MoskitoConfigurationHolder.resetConfiguration();
     }
 
-    @Before
+    @BeforeEach
     public void startUp() {
         APIFinder.addAPIFactory(AccumulatorAPI.class, new AccumulatorAPIFactory());
         APIFinder.addAPIFactory(GaugeAPI.class, new GaugeAPIFactory());
@@ -88,7 +88,7 @@ public class getDashboardTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void prepareMoskitoConfig() {
         MoskitoConfigurationHolder.resetConfiguration();
         MoskitoConfiguration moskitoConfiguration = MoskitoConfigurationHolder.getConfiguration();
@@ -102,7 +102,7 @@ public class getDashboardTest {
         MoskitoConfigurationHolder.INSTANCE.setConfiguration(moskitoConfiguration);
     }
 
-    @After
+    @AfterEach
     public void shutDown() {
         APIFinder.cleanUp();
         ProducerRegistryAPIFactory.resetForUnitTest();

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/producers/api/ProducerAPITest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/producers/api/ProducerAPITest.java
@@ -7,18 +7,18 @@ import net.anotheria.moskito.core.registry.IProducerRegistry;
 import net.anotheria.moskito.core.registry.ProducerRegistryAPIFactory;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.util.IdCodeGenerator;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class ProducerAPITest {
-	@Before
+	@BeforeEach
 	public void startUp(){
 		APIFinder.addAPIFactory(ProducerAPI.class, new ProducerAPIFactory());
 		System.setProperty("JUNITTEST", "true");
@@ -26,7 +26,7 @@ public class ProducerAPITest {
 		ProducerRegistryAPIFactory.resetForUnitTest();
 	}
 
-	@After
+	@AfterEach
 	public void shutDown(){
 		APIFinder.cleanUp();
 		ProducerRegistryFactory.reset();

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/shared/api/filter/MatchersTest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/shared/api/filter/MatchersTest.java
@@ -1,8 +1,8 @@
 package net.anotheria.moskito.webui.shared.api.filter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class MatchersTest {

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/shared/bean/DoubleValueBeanTest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/shared/bean/DoubleValueBeanTest.java
@@ -1,11 +1,11 @@
 package net.anotheria.moskito.webui.shared.bean;
 
 import net.anotheria.moskito.core.decorators.value.DoubleValueAO;
-import org.junit.Ignore;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-@Ignore
+@Disabled
 public class DoubleValueBeanTest {
 	@Test public void testFormatting(){
 		DoubleValueAO b1 = new DoubleValueAO("foo", 0.0);

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/threshold/api/ThresholdAPITest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/threshold/api/ThresholdAPITest.java
@@ -6,19 +6,19 @@ import net.anotheria.moskito.core.predefined.Constants;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
 import net.anotheria.moskito.core.stats.TimeUnit;
 import net.anotheria.moskito.core.threshold.ThresholdRepository;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class ThresholdAPITest {
-	@Before
-	@After
+	@BeforeEach
+	@AfterEach
 	public void setup(){
 		APIFinder.cleanUp();
 		APIFinder.addAPIFactory(ThresholdAPI.class, new ThresholdAPIFactory());
@@ -47,7 +47,7 @@ public class ThresholdAPITest {
 	}
 
 	//TODO refactor this test.
-	@Test @Ignore
+	@Test @Disabled
 	public void testUpdate() throws APIException {
 		ThresholdAPI api = APIFinder.findAPI(ThresholdAPI.class);
 

--- a/moskito-webui/src/test/java/net/anotheria/moskito/webui/util/DeepLinkUtilTest.java
+++ b/moskito-webui/src/test/java/net/anotheria/moskito/webui/util/DeepLinkUtilTest.java
@@ -3,14 +3,14 @@ package net.anotheria.moskito.webui.util;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpSession;
 import net.anotheria.moskito.webui.MoSKitoWebUIContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test {@link DeepLinkUtil} class
@@ -21,7 +21,7 @@ public class DeepLinkUtilTest {
      * Sets HttpSession mock in call context.
      * Otherwise {@link APILookupUtility#setCurrentConnectivityMode(ConnectivityMode)} thrown NullPointerException
      */
-    @Before
+    @BeforeEach
     public void setupWebUiContext(){
         MoSKitoWebUIContext.getCallContext().setCurrentSession(
                 new HttpSessionMock()

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>net.anotheria</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.3</version>
+		<version>4.4</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Summary

The parent was bumped to **4.4**, which provides `junit-jupiter` instead of `junit:junit` (and drops the transitively-pulled `hamcrest`). This PR makes that bump and migrates the whole test suite to JUnit 5.

Two commits:
- `updated parent version` — parent 4.3 → 4.4
- `Migrate tests from JUnit 4 to JUnit 5` — 103 files

## What changed in the migration

- **Imports/annotations:** `org.junit.*` → `org.junit.jupiter.api.*` (`@Before`/`@After`/`@BeforeClass`/`@AfterClass`/`@Ignore` → JUnit 5 equivalents, `Assert` → `Assertions`).
- **Assertion messages** moved from the first to the last argument (JUnit 5 ordering). The compiler caught the type-mismatched cases; an additional argument-aware scan caught the all-`String` cases the compiler accepts silently (e.g. `TracerTest`).
- `@Test(expected = …)` → `assertThrows(…)`; dropped an unnecessary `@RunWith(MockitoJUnitRunner)` (the test only used `mock()` directly).
- **hamcrest** `assertThat`/matchers rewritten to plain JUnit 5 assertions (hamcrest is no longer on the classpath).
- Removed the obsolete `junit:junit` dependency from `moskito-webui`.

## Verification

Full reactor `clean install`: **271 tests, 0 failures, 0 errors, 12 skipped** (the skipped ones are the pre-existing `@Ignore`, now `@Disabled` — unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)