### PR TITLE
Add Dependabot config + patch Spring CVEs in moskito-springboot2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Dependabot configuration for MoSKito
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    # Root of the Maven reactor; Dependabot discovers all child module poms from here.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    # PRs open against the default branch (develop).
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+    # Bundle routine minor/patch bumps into a single PR to cut noise;
+    # major upgrades still get their own PR so they can be reviewed in isolation.
+    groups:
+      maven-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/moskito-integration/moskito-springboot2/pom.xml
+++ b/moskito-integration/moskito-springboot2/pom.xml
@@ -30,25 +30,25 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>6.0.23</version>
+            <version>6.2.18</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-            <version>3.3.11</version>
+            <version>3.5.14</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot</artifactId>
-            <version>3.3.11</version>
+            <version>3.5.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
-            <version>3.3.11</version>
+            <version>3.5.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What

Two pieces of dependency housekeeping:

### 1. Enable Dependabot version-update PRs (`.github/dependabot.yml`)
Dependabot security **alerts** were on, but with no config file there were no routine version-update PRs. Adds weekly Maven scanning against `develop`, with minor/patch bumps grouped into one PR and majors opened individually.

### 2. Patch Spring CVEs in the active `moskito-springboot2` module
| Dependency | Before | After | Fixes |
|---|---|---|---|
| `spring-boot` (×3) | 3.3.11 | **3.5.14** | CVE-2026-40973 (predictable temp dir; no fix in 3.3.x/3.4.x) |
| `spring-web` | 6.0.23 | **6.2.18** | CVE-2024-38820 (DataBinder case sensitivity) + CVE-2025-41234 (reflected file download); EOL 6.0.x got no fix |

`6.2.18` is the Spring Framework version managed by Spring Boot 3.5.14, so this also removes the previous **6.0.23 vs 6.1.19 classpath mismatch** — the module now resolves uniformly on Spring Framework 6.2.18.

## Resolves Dependabot alerts
Closes the 3 alerts in `moskito-springboot2`: #44, #34, #36.

The remaining 4 alerts (#31, #45, #35, #37) are in `moskito-springboot` (v1), which is **disabled** (commented out in `moskito-integration/pom.xml`) — not touched here; recommend dismissing those as "won't fix" or removing the dead module.

## Verification
- `mvn -pl moskito-integration/moskito-springboot2 -am compile` passes.
- `dependency:tree` confirms all Spring artifacts resolve to 6.2.18 (no version clash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)