### PR TITLE
Replace org.json with gson in moskito-webui

### DIFF
--- a/moskito-webui/pom.xml
+++ b/moskito-webui/pom.xml
@@ -78,11 +78,6 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20231013</version>
-        </dependency>
-        <dependency>
             <groupId>net.anotheria</groupId>
             <artifactId>moskito-core</artifactId>
             <version>${project.version}</version>

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatedSingleGraphAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/AccumulatedSingleGraphAO.java
@@ -1,11 +1,8 @@
 package net.anotheria.moskito.webui.accumulators.api;
 
+import com.google.gson.JsonObject;
 import net.anotheria.moskito.core.config.thresholds.GuardConfig;
 import net.anotheria.util.StringUtils;
-import net.anotheria.util.log.LogMessageUtil;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.slf4j.LoggerFactory;
 
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -123,17 +120,10 @@ public class AccumulatedSingleGraphAO implements Serializable{
 	 *
 	 * @return JSON object with accumulator color
 	 */
-	public JSONObject mapColorDataToJSON() {
-		final JSONObject jsonObject = new JSONObject();
-
-		try {
-			jsonObject.put("name", name);
-			jsonObject.put("color", color);
-		} catch (JSONException e) {
-			final String message = LogMessageUtil.failMsg(e);
-			LoggerFactory.getLogger(AccumulatedSingleGraphAO.class).warn(message, e);
-		}
-
+	public JsonObject mapColorDataToJSON() {
+		final JsonObject jsonObject = new JsonObject();
+		jsonObject.addProperty("name", name);
+		jsonObject.addProperty("color", color);
 		return jsonObject;
 	}
 

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/MultilineChartAO.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/api/MultilineChartAO.java
@@ -1,13 +1,13 @@
 package net.anotheria.moskito.webui.accumulators.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -76,8 +76,8 @@ public class MultilineChartAO implements Serializable{
 	 * @return JSON array with accumulators colors
 	 */
 	@JsonIgnore
-	public JSONArray getAccumulatorsColorsDataJSON() {
-		final JSONArray jsonArray = new JSONArray();
+	public JsonArray getAccumulatorsColorsDataJSON() {
+		final JsonArray jsonArray = new JsonArray();
 		if (singleGraphAOs == null || singleGraphAOs.isEmpty())
 			return jsonArray;
 
@@ -85,8 +85,8 @@ public class MultilineChartAO implements Serializable{
 			if (StringUtils.isEmpty(graphAO.getName()) || StringUtils.isEmpty(graphAO.getColor()))
 				continue;
 
-			final JSONObject jsonObject = graphAO.mapColorDataToJSON();
-			jsonArray.put(jsonObject);
+			final JsonObject jsonObject = graphAO.mapColorDataToJSON();
+			jsonArray.add(jsonObject);
 		}
 
 		return jsonArray;

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/util/AccumulatorUtility.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/accumulators/util/AccumulatorUtility.java
@@ -1,9 +1,9 @@
 package net.anotheria.moskito.webui.accumulators.util;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import net.anotheria.moskito.webui.accumulators.api.AccumulatedSingleGraphAO;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import java.util.List;
 
@@ -19,15 +19,15 @@ public class AccumulatorUtility {
      * @param graphAOs collection of {@link AccumulatedSingleGraphAO}
      * @return JSON array with accumulators colors
      */
-    public static JSONArray accumulatorsColorsToJSON(final List<AccumulatedSingleGraphAO> graphAOs) {
-        final JSONArray jsonArray = new JSONArray();
+    public static JsonArray accumulatorsColorsToJSON(final List<AccumulatedSingleGraphAO> graphAOs) {
+        final JsonArray jsonArray = new JsonArray();
 
         for (AccumulatedSingleGraphAO graphAO : graphAOs) {
             if (StringUtils.isEmpty(graphAO.getName()) || StringUtils.isEmpty(graphAO.getColor()))
                 continue;
 
-            final JSONObject jsonObject = graphAO.mapColorDataToJSON();
-            jsonArray.put(jsonObject);
+            final JsonObject jsonObject = graphAO.mapColorDataToJSON();
+            jsonArray.add(jsonObject);
         }
 
         return jsonArray;

--- a/moskito-webui/src/main/java/net/anotheria/moskito/webui/more/action/UpdateAction.java
+++ b/moskito-webui/src/main/java/net/anotheria/moskito/webui/more/action/UpdateAction.java
@@ -1,11 +1,12 @@
 package net.anotheria.moskito.webui.more.action;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import net.anotheria.maf.action.ActionCommand;
 import net.anotheria.maf.action.ActionMapping;
 import net.anotheria.moskito.webui.shared.bean.NaviItem;
 import net.anotheria.util.NumberUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -44,12 +45,12 @@ public class UpdateAction extends BaseAdditionalAction {
 			while(in.available()>0){
 				jsonReply.append((char)in.read());
 			}
-			JSONObject obj = new JSONObject(jsonReply.toString());
-			JSONObject response = obj.getJSONObject("response");
-			JSONArray docs = response.getJSONArray("docs");
-			JSONObject artifact = docs.getJSONObject(0);
-			timestamp = artifact.getLong("timestamp");
-			version = artifact.getString("latestVersion");
+			JsonObject obj = JsonParser.parseString(jsonReply.toString()).getAsJsonObject();
+			JsonObject response = obj.getAsJsonObject("response");
+			JsonArray docs = response.getAsJsonArray("docs");
+			JsonObject artifact = docs.get(0).getAsJsonObject();
+			timestamp = artifact.get("timestamp").getAsLong();
+			version = artifact.get("latestVersion").getAsString();
 
 		}catch(Exception e){
 			version = "ERROR: "+e.getMessage();


### PR DESCRIPTION
## What
Removes the `org.json:json` dependency and migrates its 4 usages in `moskito-webui` to **gson**, which is already a dependency of the module.

## Why
`moskito-webui` was the only module depending on `org.json`, for a handful of small JSON build/parse sites. Consolidating on gson drops a dependency (and the recurring Dependabot bump #302), and removes duplicate JSON libraries from the tree.

## Changes
| File | Before | After |
|---|---|---|
| `AccumulatedSingleGraphAO` | `JSONObject` + try/catch(`JSONException`) | `JsonObject` + `addProperty` (no checked exception) |
| `MultilineChartAO` | `JSONArray`/`JSONObject`, `.put()` | `JsonArray`/`JsonObject`, `.add()` |
| `AccumulatorUtility` | `JSONArray`/`JSONObject`, `.put()` | `JsonArray`/`JsonObject`, `.add()` |
| `UpdateAction` | `new JSONObject(str)`, `getJSONObject/getJSONArray/getLong/getString` | `JsonParser.parseString(...)`, `getAsJsonObject/getAsJsonArray/getAsLong/getAsString` |
| `moskito-webui/pom.xml` | `org.json:json:20231013` | removed |

## Compatibility
The three builder methods are consumed only via `.toString()` — the JSON is written into a `<script>` block through `<ano:write>` (`ShowAccumulatorsAction`, `ShowProducerAction`, `ShowCumulatedProducersAction` → `Accumulators.jsp` / `Producer.jsp` / `CumulatedProducers.jsp`, plus `ChartsWidget.jsp`). gson's `JsonArray/JsonObject.toString()` emits equivalent compact JSON, so no caller or JSP changes are needed.

Minor behavioral notes (non-issues for the color/name payload here):
- gson preserves insertion order (`{"name":...,"color":...}`); org.json's HashMap order was unspecified.
- gson's `toString()` does not apply org.json's `</` → `<\/` escaping; the data is operator-configured accumulator names/hex colors, not end-user input.

## Verification
- `mvn -pl moskito-webui -am compile` and `test-compile` pass.
- `grep` confirms zero remaining `org.json` / `JSONObject` / `JSONArray` references in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)