### PR TITLE
Raise Java baseline from 11 to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,11 @@
 
 	<properties>
 		<jersey-version>3.1.3</jersey-version>
-        <source-version>11</source-version>
-        <target-version>11</target-version>
+        <source-version>17</source-version>
+        <target-version>17</target-version>
 		<aspectj.version>1.9.25.1</aspectj.version>
 		<aspectj-maven-plugin.version>1.16.0</aspectj-maven-plugin.version>
-		<aspectj-maven-plugin.complianceLevel>11</aspectj-maven-plugin.complianceLevel>
+		<aspectj-maven-plugin.complianceLevel>17</aspectj-maven-plugin.complianceLevel>
 		<moskito-webui-version>${project.version}</moskito-webui-version>
 		<distributeme.version>4.0.3</distributeme.version>
 		<moskitoplugins-version>1.0.0-SNAPSHOT</moskitoplugins-version>


### PR DESCRIPTION
## What
Bumps the compile/runtime baseline from **Java 11 to Java 17** by updating the central `source-version` / `target-version` properties (and the AspectJ `complianceLevel`) in the root pom.

## Why
- Every current Dependabot major (Spring Boot 4, Spring Framework 7, Jersey 4, the Jakarta EE 11 APIs) requires Java 17 — this unblocks that whole modern stack.
- CI already runs on JDK 17 (`pmd.yml`); we were merely emitting bytecode 11.
- Enables the language features the codebase can now standardize on (records, sealed types, switch expressions).

## Compatibility / release note
Raising the baseline is a **breaking change for consumers still on Java 11**, so this should be released as the next **major (5.0)**, not on the 4.x line. Version bump is intentionally **not** included here — that's a release-tooling step to run separately (`versions:set`).

## Verification
Full reactor `mvn clean install` — **all 23 modules SUCCESS**, tests included (0 failures / 0 errors) — on the Java 17 target.

## Follow-ups (separate PRs)
With 17 in place, the 6 major Dependabot PRs become viable and can each be tackled deliberately (Spring Boot 4 / Framework 7 / Jersey 4 / Jakarta EE 11 carry their own migration surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)