### PR TITLE
Ignore deliberately-held major bumps in Dependabot (Spring + Jakarta EE 11)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,25 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # moskito-springboot2 declares Spring as provided-scope and targets
+    # Spring Boot 2/3/4, so the compile baseline is kept low for the widest
+    # host compatibility. Allow 3.5.x security patches, but don't propose the
+    # 4.x / Framework 7 majors (Spring Boot 4 also dropped spring-boot-starter-aop).
+    ignore:
+      - dependency-name: "org.springframework.boot:spring-boot"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.springframework.boot:spring-boot-configuration-processor"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.springframework.boot:spring-boot-starter-aop"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.springframework:spring-web"
+        update-types: ["version-update:semver-major"]
+    # moskito's REST/inspect layer stays on the mature Jakarta EE 10 line
+    # (Jersey 3.1.x); hold the EE 11 majors (Jersey 4, JAX-RS 4, JSP 4). The
+    # Jersey CVE fix ships in the 3.1.x line (3.1.10+), not only in 4.x.
+      - dependency-name: "org.glassfish.jersey*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jakarta.ws.rs:jakarta.ws.rs-api"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jakarta.servlet.jsp:jakarta.servlet.jsp-api"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## What
Adds Dependabot `ignore` rules blocking **semver-major** updates for dependencies moskito deliberately holds on their current lines (minor/patch security bumps still flow).

## Groups held
**Spring (provided-scope, in `moskito-springboot2`)** — `spring-boot`, `spring-boot-configuration-processor`, `spring-boot-starter-aop`, `spring-web`:
- Module targets Spring Boot 2/3/4; the **host supplies runtime Spring**, so a 4.x/Framework 7 compile baseline adds **no security value** and risks Boot 2/3 hosts.
- Spring Boot 4.0 also **removed `spring-boot-starter-aop`**.
- Supersedes #303, #300, #301 (closed).

**Jakarta EE 11 (compile-scope REST/inspect layer)** — `org.glassfish.jersey*`, `jakarta.ws.rs-api`, `jakarta.servlet.jsp-api`:
- moskito stays on the mature **Jakarta EE 10 line (Jersey 3.1.x)**; Jersey 4.0.x is very new.
- The Jersey **CVE-2025-12383** fix ships in **3.1.10+**, so the security fix doesn't require the Jersey 4 major (handled by a separate `jersey-version` → 3.1.12 bump).
- Supersedes #298, #304, #299.

## Note
These are `version-update:semver-major` ignores only — Dependabot continues to propose minor/patch (incl. security) updates, and will now offer 3.1.x Jersey bumps instead of jumping to 4.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)