### PR TITLE
Bump Jersey 3.1.3 → 3.1.12 (CVE-2025-12383)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	</modules>
 
 	<properties>
-		<jersey-version>3.1.3</jersey-version>
+		<jersey-version>3.1.12</jersey-version>
         <source-version>17</source-version>
         <target-version>17</target-version>
 		<aspectj.version>1.9.25.1</aspectj.version>


### PR DESCRIPTION
## What
Bumps the managed `jersey-version` property from **3.1.3 → 3.1.12**.

## Why
Jersey **3.1.0–3.1.9** are affected by **CVE-2025-12383** (race condition in SSL/TLS config handling); fixed in **3.1.10+**. This stays on the mature **Jakarta EE 10** line (3.1.x) rather than jumping to the Jersey 4 major — see #308 for the ignore rules that keep Dependabot on 3.1.x.

## Verification
`mvn install` for the jersey-consuming modules — **BUILD SUCCESS**:
- `moskito-inspect-jersey`
- `moskito-webui`
- `moskito-notification-providers`

`dependency:tree` confirms all `org.glassfish.jersey.*` artifacts resolve to **3.1.12**.

Supersedes Dependabot PR #298 (which proposed the 4.0.2 major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)