### PR TITLE
Set version to 5.0.0-SNAPSHOT

### DIFF
--- a/moskito-aop/pom.xml
+++ b/moskito-aop/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>net.anotheria</groupId>
 		<artifactId>moskito</artifactId>
-		<version>4.0.10-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>moskito-aop</artifactId>
-  	<version>4.0.10-SNAPSHOT</version>
+  	<version>5.0.0-SNAPSHOT</version>
     <name>moskito aop</name>
 
     <build>

--- a/moskito-core/pom.xml
+++ b/moskito-core/pom.xml
@@ -3,12 +3,12 @@
   <parent>
 	<groupId>net.anotheria</groupId>
 	<artifactId>moskito</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-core</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>moskito core</name>
 
   <dependencies>

--- a/moskito-extensions/moskito-additional-producers/pom.xml
+++ b/moskito-extensions/moskito-additional-producers/pom.xml
@@ -3,13 +3,13 @@
   <parent>
 	<groupId>net.anotheria</groupId>
 	<artifactId>moskito</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-additional-producers</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>additional producers</name>
 
   <dependencies>

--- a/moskito-extensions/moskito-disk-space-monitoring/pom.xml
+++ b/moskito-extensions/moskito-disk-space-monitoring/pom.xml
@@ -3,13 +3,13 @@
   <parent>
 	<groupId>net.anotheria</groupId>
 	<artifactId>moskito</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-disk-space-monitoring</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>moskito disk space monitoring</name>
 
   <dependencies>

--- a/moskito-extensions/moskito-mongodb/pom.xml
+++ b/moskito-extensions/moskito-mongodb/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>moskito-extensions</artifactId>
         <groupId>net.anotheria</groupId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>moskito-mongodb</artifactId>
-    <version>4.0.10-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>moskito mongodb monitoring</name>
 
     <dependencies>

--- a/moskito-extensions/moskito-monitoring-plugin/pom.xml
+++ b/moskito-extensions/moskito-monitoring-plugin/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>moskito-extensions</artifactId>
         <groupId>net.anotheria</groupId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>moskito-monitoring-plugin</artifactId>
-    <version>4.0.10-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>moskito generic monitoring plugin</name>
     <packaging>jar</packaging>
 

--- a/moskito-extensions/moskito-notification-providers/pom.xml
+++ b/moskito-extensions/moskito-notification-providers/pom.xml
@@ -3,13 +3,13 @@
   <parent>
 	<groupId>net.anotheria</groupId>
 	<artifactId>moskito</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-notification-providers</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>notification providers</name>
 
   <dependencies>

--- a/moskito-extensions/moskito-php/pom.xml
+++ b/moskito-extensions/moskito-php/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>moskito-extensions</artifactId>
         <groupId>net.anotheria</groupId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>moskito-php</artifactId>
-    <version>4.0.10-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>MoSKito PHP Integration</name>
     <dependencies>
 

--- a/moskito-extensions/moskito-saas/pom.xml
+++ b/moskito-extensions/moskito-saas/pom.xml
@@ -3,13 +3,13 @@
   <parent>
 	<groupId>net.anotheria</groupId>
 	<artifactId>moskito</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-saas-plugin</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>moskito-saas-plugin</name>
 
   <dependencies>

--- a/moskito-extensions/moskito-sampling-api/pom.xml
+++ b/moskito-extensions/moskito-sampling-api/pom.xml
@@ -3,13 +3,13 @@
   <parent>
 	<groupId>net.anotheria</groupId>
 	<artifactId>moskito</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-sampling-api</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>sampling api</name>
 
   <dependencies>

--- a/moskito-extensions/pom.xml
+++ b/moskito-extensions/pom.xml
@@ -3,12 +3,12 @@
   <parent>
         <groupId>net.anotheria</groupId>
         <artifactId>moskito</artifactId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-extensions</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>moskito extensions aggregator</name>
   <packaging>pom</packaging>
 

--- a/moskito-inspect-standalone/pom.xml
+++ b/moskito-inspect-standalone/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<groupId>net.anotheria</groupId>
 		<artifactId>moskito</artifactId>
-		<version>4.0.10-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>moskito-inspect-standalone</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<name>MoSKito Inspect Standalone Application</name>
 	<packaging>war</packaging>
   <properties>

--- a/moskito-integration/moskito-cdi/pom.xml
+++ b/moskito-integration/moskito-cdi/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>net.anotheria</groupId>
         <artifactId>moskito</artifactId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>moskito-cdi</artifactId>
-    <version>4.0.10-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>moskito cdi integration</name>
 
     <dependencies>

--- a/moskito-integration/moskito-ehcache/pom.xml
+++ b/moskito-integration/moskito-ehcache/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>moskito-integration</artifactId>
         <groupId>net.anotheria</groupId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>moskito-ehcache</artifactId>
-    <version>4.0.10-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>moskito ehcache integration</name>
 
     <dependencies>

--- a/moskito-integration/moskito-inspect-embedded/pom.xml
+++ b/moskito-integration/moskito-inspect-embedded/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<groupId>net.anotheria</groupId>
 		<artifactId>moskito-integration</artifactId>
-		<version>4.0.10-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>moskito-inspect-embedded</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<name>moskito inspect embedded</name>
     <description>
         This project contains dependencies and configuration (web-fragment) needed to enable moskito-inspect in embedded mode. To use it simply add it as dependency.

--- a/moskito-integration/moskito-inspect-jersey/pom.xml
+++ b/moskito-integration/moskito-inspect-jersey/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<groupId>net.anotheria</groupId>
 		<artifactId>moskito-integration</artifactId>
-		<version>4.0.10-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>moskito-inspect-jersey</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<name>moskito embedded web rest interface - jersey support</name>
     <description>
         This project contains dependencies and configuration (web-fragment) needed to enable moskito-inspect rest interface via Jersey. To use it simply add it as dependency.

--- a/moskito-integration/moskito-inspect-remote/pom.xml
+++ b/moskito-integration/moskito-inspect-remote/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<groupId>net.anotheria</groupId>
 		<artifactId>moskito-integration</artifactId>
-		<version>4.0.10-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>moskito-inspect-remote</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<name>moskito inspect support for remote inspect connection</name>
     <description>
         This project contains dependencies and configuration (web-fragment) needed to enable moskito-inspect remotely. To use it simply add it as dependency.

--- a/moskito-integration/moskito-springboot2/pom.xml
+++ b/moskito-integration/moskito-springboot2/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>net.anotheria</groupId>
         <artifactId>moskito-integration</artifactId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>moskito-springboot2</artifactId>
-    <version>4.0.10-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>moskito springboot 2 integration</name>
 
     <dependencies>

--- a/moskito-integration/moskito-sql/pom.xml
+++ b/moskito-integration/moskito-sql/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>net.anotheria</groupId>
 		<artifactId>moskito</artifactId>
-		<version>4.0.10-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>moskito-sql</artifactId>
-  	<version>4.0.10-SNAPSHOT</version>
+  	<version>5.0.0-SNAPSHOT</version>
     <name>moskito sql integration</name>
 
     <build>

--- a/moskito-integration/pom.xml
+++ b/moskito-integration/pom.xml
@@ -3,12 +3,12 @@
   <parent>
         <groupId>net.anotheria</groupId>
         <artifactId>moskito</artifactId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-integration</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>moskito integration aggregator</name>
   <packaging>pom</packaging>
 

--- a/moskito-web/pom.xml
+++ b/moskito-web/pom.xml
@@ -3,12 +3,12 @@
   <parent>
 	<groupId>net.anotheria</groupId>
 	<artifactId>moskito</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>moskito-web</artifactId>
-  <version>4.0.10-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>moskito web support</name>
 
   <dependencies>

--- a/moskito-webui/pom.xml
+++ b/moskito-webui/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>net.anotheria</groupId>
         <artifactId>moskito</artifactId>
-        <version>4.0.10-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>moskito-webui</artifactId>
-    <version>4.0.10-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>moskito embedded web user interface</name>
     <build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>moskito</artifactId>
-	<version>4.0.10-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<name>MoSKito</name>
 	<description>MoSKito, the open source java monitoring</description>
 	<packaging>pom</packaging>


### PR DESCRIPTION
## What
Bumps all 23 reactor modules from `4.0.10-SNAPSHOT` → **`5.0.0-SNAPSHOT`** (via `mvn versions:set -DprocessAllModules=true`).

## Why
Raising the Java baseline from 11 → 17 (#307) is a **breaking change** for Java 11 consumers, which under semantic versioning warrants a new major. (Corroborated by the v1 module removal and the `moskito-webui` public return-type change from `org.json` → gson.)

## Notes
- The unrelated `moskitoplugins-version` property (`1.0.0-SNAPSHOT`) is intentionally left untouched.
- Version-only change — no code changes.

## Verification
Full reactor `mvn install` — **all 23 modules BUILD SUCCESS** at 5.0.0-SNAPSHOT.

## Merge order
Best merged **after** the other open 5.0-line PRs (#308 ignore rules, #309 Jersey) to avoid rebasing their branches onto the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)