### PR TITLE
Migrate moskito-mongodb to mongodb-driver-sync 5.9.0

### DIFF
--- a/moskito-extensions/moskito-mongodb/pom.xml
+++ b/moskito-extensions/moskito-mongodb/pom.xml
@@ -14,8 +14,8 @@
     <dependencies>
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver</artifactId>
-            <version>3.12.14</version>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>5.9.0</version>
         </dependency>
         <dependency>
             <groupId>net.anotheria</groupId>

--- a/moskito-extensions/moskito-mongodb/src/main/java/net/anotheria/moskito/extension/mongodb/MongodbMonitor.java
+++ b/moskito-extensions/moskito-mongodb/src/main/java/net/anotheria/moskito/extension/mongodb/MongodbMonitor.java
@@ -1,8 +1,9 @@
 package net.anotheria.moskito.extension.mongodb;
 
 import com.mongodb.*;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.util.JSON;
 import net.anotheria.moskito.core.dynamic.OnDemandStatsProducer;
 import net.anotheria.moskito.core.dynamic.OnDemandStatsProducerException;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
@@ -50,12 +51,15 @@ public class MongodbMonitor {
     }
 
     private MongoClient createClient(MongodbMonitorConfig config) {
+        ServerAddress serverAddress = new ServerAddress(config.getHost(), Integer.parseInt(config.getPort()));
+        MongoClientSettings.Builder settingsBuilder = MongoClientSettings.builder()
+                .applyToClusterSettings(builder -> builder.hosts(List.of(serverAddress)));
+
         List<MongoCredential> mongoCredentials = createMongoCredentials(config);
-        if (mongoCredentials.size() == 0) {
-            return new MongoClient(config.getHost(), Integer.parseInt(config.getPort()));
-        } else {
-            return new MongoClient(new ServerAddress(config.getHost(), Integer.parseInt(config.getPort())), mongoCredentials);
+        if (!mongoCredentials.isEmpty()) {
+            settingsBuilder.credential(mongoCredentials.get(0));
         }
+        return MongoClients.create(settingsBuilder.build());
     }
 
     private List<MongoCredential> createMongoCredentials(MongodbMonitorConfig config) {
@@ -69,10 +73,9 @@ public class MongodbMonitor {
     }
 
     private void updateMongoServerStats(MongoDatabase dbAdmin) {
-        DBObject serverStats = executeMongoCommand(dbAdmin, "serverStatus");
-        Map<String, Object> map = serverStats.toMap();
-        updateFlushing(map);
-        updateConnections(map);
+        Document serverStats = executeMongoCommand(dbAdmin, "serverStatus");
+        updateFlushing(serverStats);
+        updateConnections(serverStats);
     }
 
     private void updateFlushing(Map<String, Object> map) {
@@ -100,14 +103,13 @@ public class MongodbMonitor {
         }
     }
 
-    private DBObject executeMongoCommand(MongoDatabase db, String command) {
-        DBObject dbObject = null;
+    private Document executeMongoCommand(MongoDatabase db, String command) {
         try {
-            dbObject = (DBObject) JSON.parse(db.runCommand(new Document(command, 1)).toJson());
+            return db.runCommand(new Document(command, 1));
         } catch (MongoCommandException e) {
             LOGGER.error("Couldn't execute mongo command", e);
         }
-        return dbObject;
+        return null;
     }
 
     public static MongodbMonitor createMongodbMonitor() {


### PR DESCRIPTION
## What
Migrates `moskito-mongodb` from the legacy `org.mongodb:mongodb-driver` (3.12.14) to the modern **`org.mongodb:mongodb-driver-sync` 5.9.0**.

## Why
The 3.x driver was already at its last release (3.12.14, bumped in #297, no open CVEs), but:
- The **3.x line is EOL** — no future security fixes.
- The driver is **compile-scope** (moskito ships it), so bundling 3.x risks a **classpath clash** with host apps already on driver 5.x. Moving to 5.x aligns moskito with modern hosts.

## Changes (confined to `MongodbMonitor.java`)
- **Client creation:** legacy `new MongoClient(host, port)` / `new MongoClient(ServerAddress, credentials)` → `MongoClients.create(MongoClientSettings…)` (ServerAddress via cluster settings + single credential).
- **Command result:** dropped the `com.mongodb.util.JSON.parse(doc.toJson())` round-trip (`JSON` was removed in driver 4.x) and the legacy `DBObject`. `db.runCommand(...)` already returns an `org.bson.Document`, which is a `Map<String,Object>` and is passed straight through — net simplification.

## Notes
- Behavior preserved. The pre-existing reliance on the MMAPv1-only `backgroundFlushing` serverStatus field (removed on modern WiredTiger servers) is **unchanged / out of scope** — it's a server-version issue, not a driver one.
- The `src/main/test/...` file is not a real source root and doesn't touch the driver, so no test changes.

## Verification
`mvn install` for `moskito-mongodb` — **BUILD SUCCESS**; `dependency:tree` resolves `mongodb-driver-sync` / `-core` / `bson` at **5.9.0** with no legacy 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)