### PR TITLE
CodeQL advanced setup: analyze Java/Kotlin + Code Quality, drop test & vendored-JS noise

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,2 +1,13 @@
+# Shared CodeQL configuration, consumed by the advanced-setup workflow
+# (.github/workflows/codeql.yml) for both security code scanning and the
+# standalone Code Quality analysis.
+#
+# NOTE: path filters here are only honored under advanced setup. Default setup
+# ignores this file, which is why these exclusions previously had no effect.
 paths-ignore:
+  # Vendored / third-party front-end libraries bundled with the webui
+  # (bootstrap, jquery, tablesorter, select2, qtip2, ...). Not our code —
+  # scanning them only produces noise in libraries we don't maintain.
   - moskito-webui/src/main/resources/moskito/ext
+  # Test sources across all modules.
+  - '**/src/test/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: "CodeQL"
+
+# Advanced setup replacing CodeQL default setup. Unlike default setup this
+# workflow reads .github/codeql/codeql-config.yml (so paths-ignore applies) and
+# analyzes Java/Kotlin buildlessly (build-mode: none) instead of relying on an
+# autobuild that fails on this multi-module Maven/AspectJ project.
+#
+# IMPORTANT: CodeQL default setup must be turned off for this repository
+# (Settings -> Code security -> Code scanning -> CodeQL -> switch to Advanced),
+# otherwise default and advanced setup conflict.
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+  schedule:
+    - cron: '25 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+          # Populate the standalone Code Quality section in addition to the
+          # default security code-scanning queries.
+          quality-queries: code-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What
Replaces CodeQL **default setup** with an **advanced-setup** workflow (`.github/workflows/codeql.yml`) plus an updated shared config (`.github/codeql/codeql-config.yml`).

## Why (the current setup is broken for our needs)
- Default setup **never analyzes Java/Kotlin** — its autobuild fails on this multi-module Maven/AspectJ project, so we get no coverage of our actual code.
- All it surfaces is **JS security noise from vendored third-party libraries** under `moskito-webui/src/main/resources/moskito/ext` (bootstrap, jQuery, tablesorter, select2, qtip2 …) — 52 alerts in code we don't maintain.
- The existing `codeql-config.yml` already tried to `paths-ignore` that vendored dir, but **default setup ignores the config file**, so it never took effect.

## What the new setup does
- **Analyzes `java-kotlin` and `javascript-typescript` with `build-mode: none`** — buildless extraction, so there's no autobuild to fail.
- **Reads `codeql-config.yml`**, so `paths-ignore` finally applies.
- **Enables the standalone Code Quality section** via `quality-queries: code-quality`.
- **Excludes** the vendored webui JS (`moskito/ext`) and **all test sources** (`**/src/test/**`).

Net result: real Java/Kotlin security + quality coverage, no vendored-JS noise, no test-class findings.

## ⚠️ Required manual step
CodeQL **default setup must be switched to Advanced** for this repo (Settings → Code security → Code scanning → CodeQL → Advanced), or default and advanced setup conflict and the workflow won't run.

## Caveats to verify on first run
1. **`quality-queries: code-quality`** is the (recent) input that drives the standalone Code Quality section rather than folding quality into the security alerts. Worth confirming the Code Quality view populates after the first run.
2. **`paths-ignore` for Java is best-effort.** Path filtering is fully reliable for interpreted languages; for compiled languages GitHub documents build-step scoping as the reliable route. With `build-mode: none` it typically behaves buildless, but if Java test-class findings still appear we'll scope them differently.

## Verification
Both YAML files parse; `paths-ignore` = `[moskito/ext, **/src/test/**]`; matrix = `[java-kotlin, javascript-typescript]`. Behavior confirmed against the first Actions run once default setup is switched off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)